### PR TITLE
IPython 2.x compatibility and some styling.

### DIFF
--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -59,3 +59,4 @@ opacity: 1.0;
 .toolbar {
 padding: 10px;
 }
+

--- a/livereveal/reveal.js/css/ipython_reveal.css
+++ b/livereveal/reveal.js/css/ipython_reveal.css
@@ -504,11 +504,11 @@ body {
 .reveal .slide-number {
 	position: fixed;
 	display: block;
-	right: 15px;
-	bottom: 15px;
-	opacity: 0.5;
+	left: 1em;
+	bottom: 2.2em;
+	opacity: 0.8;
 	z-index: 31;
-	font-size: 12px;
+	font-size: 1.4em;
 }
 
 /*********************************************


### PR DESCRIPTION
Yes, I do PR against myself ;-)
- IPy 2.x compat
- toggleOverview() on `w`
- New close button
- Slide number
- UP and DOWN arrow deactivated on reveal to let interface with IPython
- SHIFT-ENTER == CTRL-ENTER to avoid desynchronisation between execute_and_next_cell and slide progression.
