### PR TITLE
Use frontend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,31 @@ if you insist about doing it manually, just copy the extension (the
 directory and then, throw the `custom.js` I have added to the repo inside
 `your_profile/static/custom` directory.
 
-## Usage with leap motion.
+## Usage with Leap Motion
 
-**Reveal.js** support the [leap motion](leapmotion.com). You can use RISE with
-the leap motion if your local computer have a leap motion installed. Simply
-pass the [reveal leap plugin options](https://github.com/hakimel/reveal.js#leap-motion)
-as a third parameter of your reveal js parameters, for example in `custom.js`:
+**Reveal.js** supports the [Leap Motion](leapmotion.com) controller.
+To control RISE slideshows with the Leap, put the
+[reveal leap plugin options](https://github.com/hakimel/reveal.js#leap-motion)
+in your config by running this Python code:
 
-```javascript
-livereveal.parameters('simple', 'linear', 
-    {
-    leap: {
-        naturalSwipe   : true,    // Invert swipe gestures
-        pointerOpacity : 0.5,      // Set pointer opacity to 0.5
-        pointerColor   : '#d80000' // Red pointer
-        },
+```python
+from IPython.html.services.config import ConfigManager
+cm = ConfigManager()
+cm.update('livereveal', {
+    'leap_motion': {
+        'naturalSwipe'  : True,     # Invert swipe gestures
+        'pointerOpacity': 0.5,      # Set pointer opacity to 0.5
+        'pointerColor'  : '#d80000',# Red pointer
     }
-);
+})
+```
+
+To disable it:
+
+```python
+from IPython.html.services.config import ConfigManager
+cm = ConfigManager()
+cm.update('livereveal', {'leap_motion': None})
 ```
 
 ## Feedback

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from IPython.html.nbextensions import install_nbextension
+from IPython.html.services.config import ConfigManager
 from IPython.utils.path import locate_profile
 
 
@@ -28,41 +29,16 @@ $([IPython.events]).on('app_initialized.NotebookApp', function(){
 """
 
 
-def install(use_symlink=False, profile='default'):
+def install(use_symlink=False, profile='default', enable=True):
     # Install the livereveal code.
     install_nbextension(livereveal_dir, symlink=use_symlink,
-                        overwrite=use_symlink)
+                        overwrite=use_symlink, user=True)
 
-    # Enable the extension in the given profile.
-    profile_dir = locate_profile(profile)
-    custom_js = os.path.join(profile_dir, 'static',
-                             'custom', 'custom.js')
-    add_if_not_in_custom_js(custom_js, 'LIVE_REVEAL', custom_js_entry)
-
-
-def add_if_not_in_custom_js(custom_js_fpath, ext_name, custom_js_content):
-    start_line = '// {} START'.format(ext_name.upper())
-    end_line = '// {} END'.format(ext_name.upper())
-    
-    with open(custom_js_fpath, 'r') as fh:
-        lines = list(fh)
-    
-    should_add = True
-    for line in lines:
-        if line.strip() == start_line:
-            should_add = False
-            break
-    
-    if should_add:
-        print('Writing the custom.js entry.')
-        with open(custom_js_fpath, 'w') as fh:
-            for line in lines:
-                fh.write(line)
-            fh.write('\n{}'.format(start_line))
-            fh.write(custom_js_content)
-            fh.write('\n{}'.format(end_line))
-    else:
-        print('custom.js entry already exists.')
+    if enable:
+        # Enable the extension in the given profile.
+        profile_dir = locate_profile(profile)
+        cm = ConfigManager(profile_dir=profile_dir)
+        cm.update('notebook', {"load_extensions": {"livereveal/main": True}})
 
 
 def main():
@@ -78,12 +54,15 @@ def main():
     install_parser.add_argument('--develop', action='store_true',
                                 help=("Install livereveal  as a "
                                       "symlink to the source."))
+    install_parser.add_argument('--no-enable', action='store_true',
+                                help="Install but don't enable the extension.")
     install_parser.add_argument('--profile', action='store', default='default',
                                 help=("The name of the profile to use."))                                  
     
     args = parser.parse_args(sys.argv[1:])
 
-    install(use_symlink=args.develop, profile=args.profile)
+    install(use_symlink=args.develop, profile=args.profile,
+            enable=(not args.no_enable))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -7,28 +7,6 @@ from IPython.utils.path import locate_profile
 livereveal_dir = os.path.join(os.path.dirname(__file__), 'livereveal')
 
 
-custom_js_entry = """
-
-// to prevent timeout
-requirejs.config({
-    waitSeconds: 60
-});
-
-$([IPython.events]).on('app_initialized.NotebookApp', function(){
-
-     require(['nbextensions/livereveal/main'],function(livereveal){
-       // livereveal.parameters('theme', 'transition', 'fontsize', static_prefix);
-       //   * theme can be: simple, sky, beige, serif, solarized
-       //   (you will need aditional css for default, night, moon themes).
-       //   * transition can be: linear, zoom, fade, none
-       livereveal.parameters('simple', 'zoom');
-       console.log('Live reveal extension loaded correctly');
-     });
-
-});
-"""
-
-
 def install(use_symlink=False, profile='default', enable=True):
     # Install the livereveal code.
     install_nbextension(livereveal_dir, symlink=use_symlink,


### PR DESCRIPTION
Another significant change, but not such a big diff as the last one. This uses the new frontend config system to store user preferences, rather than putting them in custom.js where the extension is loaded.

This has the great advantage that it allows livereveal to be loaded as a regular extension, which allows the installation code to be much simpler. The new installation code will fail with an ImportError on IPython 2.x, rather than installing something that won't work.

N.B. Any users who have symlinked the extension using `setup.py install --develop` will need to reinstall it after this change, because the call to `livereveal.parameters()` in their custom.js won't work.

Addresses #55 