### PR TITLE
Config for where the slideshow starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ cm.update('notebook', {"load_extensions": {"livereveal/main": False}})
 
 ## Configure your own options
 
-You can configure the `theme` and the `transition` of your slides just running
-this python code:
+You can configure the `theme` and the `transition` of your slides, and where
+slideshows start from, by running this python code:
 
 ```python
 from IPython.html.services.config import ConfigManager
@@ -94,10 +94,13 @@ cm = ConfigManager()
 cm.update('livereveal', {
               'theme': 'serif',
               'transition': 'zoom',
+              'start_slideshow_at': 'selected',
 })
 ```
 
-and now your slides will get the `serif` theme and the `zoom` transition.
+With these options, your slides will get the `serif` theme and the
+`zoom` transition, and slideshows will start from the selected cell (instead
+of from the beginning, which is the default).
 
 ## Usage with Leap Motion
 

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -118,7 +118,12 @@ function markupSlides(container) {
     return selected_cell_slide;
 }
 
-// Set the #slide-x-y part of the URL to control where the slideshow will start
+/* Set the #slide-x-y part of the URL to control where the slideshow will start.
+ * N.B. We do this instead of using Reveal.slide() after reveal initialises,
+ * because that leaves one slide clearly visible on screen for a moment before
+ * changing to the one we want. By changing the URL before setting up reveal,
+ * the slideshow really starts on the desired slide.
+ */
 function setStartingSlide(selected) {
     var start_slideshow = config.get_sync('start_slideshow_at');
     if (start_slideshow === 'selected') {


### PR DESCRIPTION
Slideshows start at the beginning by default, but by setting a config option, you can make them start at the slide containing the currently selected cell.

Closes #66