### PR TITLE
Hide anchor links

### DIFF
--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -101,7 +101,9 @@ div.output_subarea {
   font-size: 100%;
   max-width: 960px !important;  /* fix for firefox issue in IPython, 1240px */
 }
+a.anchor-link {
+  display: none;
+}
 html {
   overflow-y: auto;
 }
-


### PR DESCRIPTION
When you have a slide with section names, such as

    # The title
    contents...

the notebook displays an anchor link `¶` at the end of section name, so that you can easily link between sections.

I see no point in showing this anchor link in presentation mode: it is distracting every time the mouse passes over it, and it does not even work (clicking it moves you to the start of the presentation).

How about hiding it?
