### PR TITLE
Do not restrict the size of iframes otherwise we get a scrolbar

### DIFF
--- a/livereveal/reset_reveal.css
+++ b/livereveal/reset_reveal.css
@@ -233,8 +233,7 @@ body {
 
 /* Ensure certain elements are never larger than the slide itself */
 .reveal img,
-.reveal video,
-.reveal iframe {
+.reveal video {
 	max-width: 95%;
 	max-height: 95%;
 }


### PR DESCRIPTION
I'm working on a presentation where I embed some tikz code that is converted to SVG by tikzmagic.  The SVG is inserted using an iframe to work around [some issues with glyphs](http://python.6.x6.nabble.com/Problems-with-tikzmagic-and-svg-output-td5075252.html).  Unfortunately the `reset_reveal.css` style restricts the size of the iframe to 95% of its size, causing unwelcome scrollbars to appear only in reveal mode:

![before](https://cloud.githubusercontent.com/assets/822900/6814241/257aef08-d27d-11e4-96d7-cc5de752bb1c.png)

Removing this CSS entry fixes it.  The size of the iframe is already constrained by the notebook itself anyway.