### PR TITLE
Fix size of texts in Button, Text, and Dropdown widgets.

### DIFF
--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -82,6 +82,14 @@ background-color: #ffffff;
 .ctb_global_show div.ctb_hideshow.ctb_show {
   display: none;
 }
+div.widget-area .form-control,
+div.widget-area .dropdown-menu,
+div.widget-area .btn {
+  font-size: inherit;
+}
+div.widget-area ul.dropdown-menu {
+  margin: 0px; /* cancel the settings from reveal */
+}
 .cell li {
   line-height: 160%;
 }


### PR DESCRIPTION
I'm using RISE for interactive presentation, but the presentation is not about Python and I don't want to show any Python code.  Instead I use widgets for interactive input/output, and hide all the python code.

Unfortunately it seems the size of the text appearing in the widgets is hard-coded in the notebook style, and it is too small for a presentation.  There is also an issue with drop-down menus, because Reveal.js setups some left indentation for all `<ul>` elements.

Here are two screenshots taken in presentation mode, before and after the patch.

Before:
![before](https://cloud.githubusercontent.com/assets/822900/6887380/fc584794-d65d-11e4-8cf9-482d4e858c78.png)

After:
![after](https://cloud.githubusercontent.com/assets/822900/6887382/02ab3e62-d65e-11e4-838d-cbce1e994985.png)
