### PR TITLE
hide the cell toolbox frame

### DIFF
--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -82,6 +82,9 @@ background-color: #ffffff;
 .ctb_global_show div.ctb_hideshow.ctb_show {
   display: none;
 }
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+  border-style: none;
+}
 div.widget-area .form-control,
 div.widget-area .dropdown-menu,
 div.widget-area .btn {


### PR DESCRIPTION
Looking into why I have some frame displayed around my Markdown cells in presentation mode (see picture below), I realize that 67c92cc did not completely solve #39.

![frames](https://cloud.githubusercontent.com/assets/822900/6926508/06483bf8-d7e7-11e4-8dcc-b886c94b3a3f.png)

In a notebook, markdown cells are not framed unless the cell toolbox is active.  So if we hide the cell toolbox, we should also hide the frame.