### PR TITLE
do not define a style for table elements

### DIFF
--- a/livereveal/reset_reveal.css
+++ b/livereveal/reset_reveal.css
@@ -348,16 +348,6 @@ body {
 	        box-sizing: border-box;
 }
 
-.reveal table th,
-.reveal table td {
-	text-align: left;
-	padding-right: .3em;
-}
-
-.reveal table th {
-	font-weight: bold;
-}
-
 .reveal sup {
 	vertical-align: super;
 }


### PR DESCRIPTION
The notebook already has one, and the definition that was in reset_reveal.css
also conflicts with any user style.

This fixes #82.