### PR TITLE
remove Reveal's event listeners on exit

### DIFF
--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -314,6 +314,7 @@ function buttonExit() {
 }
 
 function Remover() {
+  Reveal.removeEventListeners();
   $('div#site').css("height", "");
   $('div#site').css('background-color','');
   $("div#ipython-main-app").css("position", "");


### PR DESCRIPTION
This fix some odd bug that has bothered me since I've started using RISE.  Typically, at some point after moving back from presentation mode and moving my navigator between different screens, I would get something like this:

![incorrect size](https://cloud.githubusercontent.com/assets/822900/6987666/ef33645a-da49-11e4-837a-f6b92046d46c.png)

The height of the notebook container (the white rectangle in the background) is smaller than the notebook itself, preventing me from scrolling further down.  Whenever I hit this situation, I had to reload the page to fix it.

Today I've realized I can reliably reproduce the issue as follows:
1. prepare a notebook that is longer than the height of your screen
2. switch to presentation mode
3. switch back to notebook mode
4. resize your browser to a small window
5. enlarge the window again

It turns out the issue comes from event listeners installed by Reveal to detect whenever the size of the page changes.  So at steps 4 & 5 above, the listener detect a page change, and forces the width and height of the notebook to something that is not relevant anymore (you can see the width and height settings on `div#notebook-container` at the bottom of my screen shot).

The fix is simply to remove the event listeners whenever we exit presentation mode.
