### PR TITLE
Bookmarkletability

### DIFF
--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -8,7 +8,8 @@
 * -----------------------------------------------------------------------------
 */
 
-define(['require',
+define([
+        'require',
         'jquery',
         'base/js/utils',
         'services/config',
@@ -155,13 +156,13 @@ function Revealer() {
   $('div#notebook-container').addClass("slides");
 
   // Header
-  $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./nbextensions/livereveal/reveal.js/css/theme/simple.css") + ' id="theme" />');
-  $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./nbextensions/livereveal/reset_reveal.css") + ' id="revealcss" />');
-  $('head').append('<link rel="stylesheet" href=' + require.toUrl("./nbextensions/livereveal/main.css") + ' id="maincss" />');
+  $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./reveal.js/css/theme/simple.css") + ' id="theme" />');
+  $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./reset_reveal.css") + ' id="revealcss" />');
+  $('head').append('<link rel="stylesheet" href=' + require.toUrl("./main.css") + ' id="maincss" />');
 
   // Tailer
-  require(['nbextensions/livereveal/reveal.js/lib/js/head.min',
-           'nbextensions/livereveal/reveal.js/js/reveal'],function(){
+  require(['./reveal.js/lib/js/head.min.js',
+           './reveal.js/js/reveal.js'],function(){
     // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
 
     var options = {
@@ -207,14 +208,14 @@ function Revealer() {
     dependencies: [
             //{ src: "static/custom/livereveal/reveal.js/lib/js/classList.js", condition: function() { return !document.body.classList; } },
             //{ src: "static/custom/livereveal/reveal.js/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-            { src: require.toUrl("./nbextensions/livereveal/reveal.js/plugin/notes/notes.js"), async: true, condition: function() { return !!document.body.classList; } }
+            { src: require.toUrl("./reveal.js/plugin/notes/notes.js"), async: true, condition: function() { return !!document.body.classList; } }
         ]
     };
 
     // Set up the Leap Motion integration if configured
     var leap = config.get_sync('leap_motion');
     if (leap !== undefined) {
-        options.dependencies.push({ src: require.toUrl('./nbextensions/livereveal/reveal.js/plugin/leap/leap.js'), async: true });
+        options.dependencies.push({ src: require.toUrl('./reveal.js/plugin/leap/leap.js'), async: true });
         options.leap = leap;
     }
 

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -8,10 +8,11 @@
 * -----------------------------------------------------------------------------
 */
 
-define(['jquery',
+define(['require',
+        'jquery',
         'base/js/utils',
         'services/config',
-], function($, utils, configmod) {
+], function(require, $, utils, configmod) {
 
 var config_section = new configmod.ConfigSection('livereveal',
                             {base_url: utils.get_body_data("baseUrl")});

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -400,24 +400,26 @@ function revealMode() {
   }
 }
 
-  return {
-    load_ipython_extension: function setup() {
-      IPython.toolbar.add_buttons_group([
-        {
-        'label'   : 'Enter/Exit Live Reveal Slideshow',
-        'icon'    : 'fa-bar-chart-o',
-        'callback': function(){ revealMode(); },
-        'id'      : 'start_livereveal'
-        },
-      ]);
-      var document_keydown = function(event) {
-        if (event.which == 82 && event.altKey) {
-          revealMode();
-          return false;
-        }
-        return true;
-      };
-      $(document).keydown(document_keydown);
+function setup() {
+  IPython.toolbar.add_buttons_group([
+    {
+    'label'   : 'Enter/Exit Live Reveal Slideshow',
+    'icon'    : 'fa-bar-chart-o',
+    'callback': function(){ revealMode(); },
+    'id'      : 'start_livereveal'
+    },
+  ]);
+  var document_keydown = function(event) {
+    if (event.which == 82 && event.altKey) {
+      revealMode();
+      return false;
     }
+    return true;
   };
+  $(document).keydown(document_keydown);
+}
+
+setup.load_ipython_extension = setup;
+
+return setup;
 });

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -162,7 +162,7 @@ function Revealer() {
 
   // Tailer
   require(['./reveal.js/lib/js/head.min.js',
-           './reveal.js/js/reveal.js'],function(){
+           './reveal.js/js/reveal.js'].map(require.toUrl),function(){
     // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
 
     var options = {


### PR DESCRIPTION
Implements #123, which enables use of RISE on any running Jupyter notebook via a bookmarklet.

## Try it!
Drag this _temporary_ gh-pages link (I'll take it down once there is a plan for permanent hosting) to the browser's bookmark bar.

```javascript
javascript:require(["//bollwyvl.github.io/live_reveal/livereveal/main.js"], function(r){r();});
```

I like testing it on `try.jupyter.org`, as all of my local stuff is polluted with development. You just click it, and the button shows up, hooray! Science bless `require`! I made `setup` a pun for `load_ipython_extension`, so the returned object is callable and less API-leaky.

## Hosting
On `gh-pages`, the bookmarklet gets served up all gzipped, CDNed and lovely, with the proper headers, over HTTPS, and [other](http://nytimes.github.io/svg-crowbar/) [folks](https://github.com/zeman/perfmap) [do](https://github.com/danlec/Trello-Bookmarklet) [it](https://github.com/dougal/github-bookmarklet) so I guess it's okay.

## Next steps?
I do wonder if we shouldn't load all the dependencies up front, rather than waiting for the first time the live mode is activated... it's a little weird on my slow connection, as the notebook stays in normal notebook mode and then switches over to the first slide.

Perhaps the best thing to do before documenting/publicizing would be to make and maintain a `gh-pages` (maybe [with Travis](https://gist.github.com/domenic/ec8b0fc8ab45f39403dd)) to host the bookmarklet on an `index.html`, which would include a nice draggable link in a TRY IT NOW call to action.... perhaps in a nbconverted reveal presentation with the contents of the `README`, generated from a `README.ipynb`?

Additionally, if `setup` accepted a config object, that might be a nice way to make more of the options configurable (bookmarklet generator?), even if they wouldn't live on in metadata (yet) on nbviewer/nbconvert.