### PR TITLE
Mode transitions, LESS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+node_modules

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ cm = ConfigManager(profile_dir=locate_profile(get_ipython().profile))
 cm.update('livereveal', {'leap_motion': None})
 ```
 
+## Development
+To build the CSS assets, you'll need `npm` (and `node`) installed.
+
+```bash
+npm install
+npm run build
+```
+
 ## Feedback
 
 If you have any feedback, or find any bugs, please let me know just opening

--- a/README.md
+++ b/README.md
@@ -176,11 +176,16 @@ cm.update('livereveal', {'leap_motion': None})
 ```
 
 ## Development
-To build the CSS assets, you'll need `npm` (and `node`) installed.
+To build the CSS assets, you'll need to install `npm` (and `node`).
 
 ```bash
 npm install
 npm run build
+```
+
+To have per-save automatic building of CSS, use:
+```bash
+npm run watch-less
 ```
 
 ## Feedback

--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -136,10 +136,10 @@
   box-shadow: none;
   width: 100%;
 }
-.rise-enabled .ctb_global_show .ctb_hideshow.ctb_show {
+.rise-enabled.ctb_global_show .ctb_hideshow.ctb_show {
   display: none;
 }
-.rise-enabled .ctb_global_show .ctb_show ~ .text_cell_render {
+.rise-enabled.ctb_global_show .ctb_show ~ .text_cell_render {
   border-style: none;
 }
 .rise-enabled .celltoolbar {

--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -1,146 +1,266 @@
-/* Reveal-specific */
-.reveal .slides {
+.transition-all {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+}
+.rise-enabled {
+  background-color: #fff;
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  /* Reveal-specific */
+  /* Notebook-specific */
+}
+.rise-enabled .reveal {
+  /* element-overrides */
+}
+.rise-enabled .reveal.fade {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  opacity: 1;
+}
+.rise-enabled .reveal pre {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  font-size: 90%;
+  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
+  overflow: hidden;
+}
+.rise-enabled .reveal section img {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  border: 0px solid black;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0);
+  -webkit-transition: none;
+          transition: none;
+}
+.rise-enabled .reveal blockquote p:first-child,
+.rise-enabled .reveal blockquote p:last-child {
+  display: inherit;
+}
+.rise-enabled .reveal .slides {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   text-align: left;
   font-size: 160%;
 }
-.reveal pre {
-  font-size: 90%;
-  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
-  overflow-y: hidden;
-  overflow-x: hidden;
-}
-.reveal section img {
-  border: 0px solid black;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0);
-  transition: none;
-}
-.reveal blockquote p:first-child, .reveal blockquote p:last-child {
-  display: inherit;
-}
-.reveal.fade {
-  opacity: 1;
-}
-.reveal .slide-number {
+.rise-enabled .reveal .slide-number {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   right: 3.1em;
   bottom: 3.9em;
   font-size: 100%;
 }
-.reveal .controls div.navigate-left,
-.reveal .controls div.navigate-left.enabled {
+.rise-enabled .reveal .controls .navigate-left,
+.rise-enabled .reveal .controls .navigate-left.enabled {
   border-right-color: #727272;
 }
-.reveal .controls div.navigate-right,
-.reveal .controls div.navigate-right.enabled {
-  border-left-color: #727272;
-}
-.reveal .controls div.navigate-up,
-.reveal .controls div.navigate-up.enabled {
-  border-bottom-color: #727272;
-}
-.reveal .controls div.navigate-down,
-.reveal .controls div.navigate-down.enabled {
-  border-top-color: #727272;
-}
-.reveal .controls div.navigate-left.enabled:hover {
+.rise-enabled .reveal .controls .navigate-left.enabled:hover,
+.rise-enabled .reveal .controls .navigate-left.enabled.enabled:hover {
   border-right-color: #dfdfdf;
 }
-.reveal .controls div.navigate-right.enabled:hover {
+.rise-enabled .reveal .controls .navigate-right,
+.rise-enabled .reveal .controls .navigate-right.enabled {
+  border-left-color: #727272;
+}
+.rise-enabled .reveal .controls .navigate-right.enabled:hover,
+.rise-enabled .reveal .controls .navigate-right.enabled.enabled:hover {
   border-left-color: #dfdfdf;
 }
-.reveal .controls div.navigate-up.enabled:hover {
+.rise-enabled .reveal .controls .navigate-up,
+.rise-enabled .reveal .controls .navigate-up.enabled {
+  border-bottom-color: #727272;
+}
+.rise-enabled .reveal .controls .navigate-up.enabled:hover,
+.rise-enabled .reveal .controls .navigate-up.enabled.enabled:hover {
   border-bottom-color: #dfdfdf;
 }
-.reveal .controls div.navigate-down.enabled:hover {
+.rise-enabled .reveal .controls .navigate-down,
+.rise-enabled .reveal .controls .navigate-down.enabled {
+  border-top-color: #727272;
+}
+.rise-enabled .reveal .controls .navigate-down.enabled:hover,
+.rise-enabled .reveal .controls .navigate-down.enabled.enabled:hover {
   border-top-color: #dfdfdf;
 }
-.progress {
-  margin-bottom: 0px;
+.rise-enabled .reveal .progress {
+  margin-bottom: 0;
 }
-.reveal .progress span {
+.rise-enabled .reveal .progress span {
   background: #727272;
 }
-.reveal .reveal-skip {
+.rise-enabled .reveal .reveal-skip,
+.rise-enabled .reveal .reveal-notes {
   display: none;
 }
-.reveal .reveal-notes {
-  display: none;
-}
-
-/* Notebook-specific */
-div#notebook {
+.rise-enabled #notebook {
   overflow: hidden;
 }
-div#notebook.reveal {
+.rise-enabled #notebook.reveal {
   padding-top: 0px;
 }
-div#notebook-container {
+.rise-enabled #notebook-container {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   background-color: transparent;
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
-.notebook_app {
-background-color: #ffffff;
-}
-.ctb_global_show div.ctb_hideshow.ctb_show {
+.rise-enabled .ctb_global_show .ctb_hideshow.ctb_show {
   display: none;
 }
-.ctb_global_show .ctb_show ~ div.text_cell_render {
+.rise-enabled .ctb_global_show .ctb_show ~ .text_cell_render {
   border-style: none;
 }
-div.widget-area .form-control,
-div.widget-area .dropdown-menu,
-div.widget-area .btn {
+.rise-enabled .widget-area .form-control,
+.rise-enabled .widget-area .dropdown-menu,
+.rise-enabled .widget-area .btn {
   font-size: inherit;
 }
-div.widget-area ul.dropdown-menu {
-  margin: 0px; /* cancel the settings from reveal */
+.rise-enabled .widget-area .dropdown-menu {
+  margin: 0px;
+  /* cancel the settings from reveal */
 }
-.cell li {
+.rise-enabled .cell li {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   line-height: 160%;
 }
-div.text_cell {
+.rise-enabled .text_cell {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   font-size: 160%;
 }
-div.text_cell .prompt{
+.rise-enabled .text_cell .prompt {
   display: none;
 }
-div.text_cell.rendered .rendered_html {
+.rise-enabled .text_cell.rendered .rendered_html {
   overflow-y: hidden;
 }
-div.prompt {
+.rise-enabled .prompt {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   font-size: 90%;
 }
-div.output_prompt {
+.rise-enabled .output_prompt {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   margin-top: 2px;
 }
-div.output_subarea {
+.rise-enabled .output_subarea {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   margin-top: 0.05em;
 }
-.CodeMirror {
+.rise-enabled .CodeMirror {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
   font-size: 100%;
-  max-width: 960px !important;  /* fix for firefox issue in IPython, 1240px */
+  max-width: 960px !important;
+  /* fix for firefox issue in IPython, 1240px */
 }
-a.anchor-link {
+.rise-enabled a.anchor-link {
   display: none;
 }
-html {
+.rise-enabled html {
   overflow-y: auto;
 }
-kbd {
+.rise-enabled .dialog kbd {
   padding: .1em .6em;
   border: 1px solid #ccc;
   font-size: 11px;
   background-color: #f7f7f7;
   color: #333;
-  -moz-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  -webkit-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  -moz-border-radius: 3px;
-  -webkit-border-radius: 3px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
   border-radius: 3px;
   display: inline-block;
   margin: 0 .1em;
   text-shadow: 0 1px 0 #fff;
   line-height: 1.4;
   white-space: nowrap;
+}
+.rise-enabled #header {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  top: -200px;
+  opacity: 0;
+}
+.rise-enabled #site {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  height: 100%;
+}
+.rise-enabled #ipython-main-app {
+  position: static;
+}
+#header {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+  opacity: 1;
+  top: 0px;
 }

--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -1,8 +1,8 @@
 .transition-all {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
 }
@@ -10,8 +10,8 @@
   background-color: #fff;
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   /* Reveal-specific */
@@ -23,8 +23,8 @@
 .rise-enabled .reveal.fade {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   opacity: 1;
@@ -32,8 +32,8 @@
 .rise-enabled .reveal pre {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   font-size: 90%;
@@ -43,8 +43,8 @@
 .rise-enabled .reveal section img {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   border: 0px solid black;
@@ -59,8 +59,8 @@
 .rise-enabled .reveal .slides {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   text-align: left;
@@ -69,8 +69,8 @@
 .rise-enabled .reveal .slide-number {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   right: 3.1em;
@@ -128,18 +128,27 @@
 .rise-enabled #notebook-container {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   background-color: transparent;
   box-shadow: none;
+  width: 100%;
 }
 .rise-enabled .ctb_global_show .ctb_hideshow.ctb_show {
   display: none;
 }
 .rise-enabled .ctb_global_show .ctb_show ~ .text_cell_render {
   border-style: none;
+}
+.rise-enabled .celltoolbar {
+  height: inherit;
+}
+.rise-enabled .celltoolbar select,
+.rise-enabled .celltoolbar .btn {
+  height: inherit;
+  font-size: inherit;
 }
 .rise-enabled .widget-area .form-control,
 .rise-enabled .widget-area .dropdown-menu,
@@ -151,21 +160,9 @@
   /* cancel the settings from reveal */
 }
 .rise-enabled .cell li {
-  -webkit-transition-property: all;
-          transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
-  -webkit-transition-timing-function: ease;
-          transition-timing-function: ease;
   line-height: 160%;
 }
 .rise-enabled .text_cell {
-  -webkit-transition-property: all;
-          transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
-  -webkit-transition-timing-function: ease;
-          transition-timing-function: ease;
   font-size: 160%;
 }
 .rise-enabled .text_cell .prompt {
@@ -177,8 +174,8 @@
 .rise-enabled .prompt {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   font-size: 90%;
@@ -186,8 +183,8 @@
 .rise-enabled .output_prompt {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   margin-top: 2px;
@@ -195,8 +192,8 @@
 .rise-enabled .output_subarea {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   margin-top: 0.05em;
@@ -204,8 +201,8 @@
 .rise-enabled .CodeMirror {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   font-size: 100%;
@@ -235,8 +232,8 @@
 .rise-enabled #header {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   top: -200px;
@@ -245,8 +242,8 @@
 .rise-enabled #site {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   height: 100%;
@@ -257,10 +254,26 @@
 #header {
   -webkit-transition-property: all;
           transition-property: all;
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
   -webkit-transition-timing-function: ease;
           transition-timing-function: ease;
   opacity: 1;
   top: 0px;
+}
+#notebook-container {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
+}
+#notebook {
+  -webkit-transition-property: all;
+          transition-property: all;
+  -webkit-transition-duration: 0.2s;
+          transition-duration: 0.2s;
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease;
 }

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -148,17 +148,17 @@ function setStartingSlide(selected) {
 
 
 function Revealer() {
+  $('body').addClass("rise-enabled");
   // Prepare the DOM to start the slideshow
-  $('div#header').hide();
-  $('div#site').css("height", "100%");
-  $('div#ipython-main-app').css("position", "static");
+  //$('div#header').hide();
+  //$('div#site').css("height", "100%");
+  //$('div#ipython-main-app').css("position", "static");
   $('div#notebook').addClass("reveal");
   $('div#notebook-container').addClass("slides");
 
   // Header
   $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./reveal.js/css/theme/simple.css") + ' id="theme" />');
   $('head').prepend('<link rel="stylesheet" href=' + require.toUrl("./reset_reveal.css") + ' id="revealcss" />');
-  $('head').append('<link rel="stylesheet" href=' + require.toUrl("./main.css") + ' id="maincss" />');
 
   // Tailer
   require(['./reveal.js/lib/js/head.min.js',
@@ -337,11 +337,9 @@ function buttonExit() {
 function Remover() {
   Reveal.configure({minScale: 1.0});
   Reveal.removeEventListeners();
+  $('body').removeClass("rise-enabled");
   $('div#site').css("height", "");
-  $('div#site').css('background-color','');
-  $("div#ipython-main-app").css("position", "");
-  $('div#header').show();
-  $('div#maintoolbar').show();
+  //$('div#maintoolbar').show();
   IPython.menubar._size_header();
 
   $('div#notebook').removeClass("reveal");
@@ -350,7 +348,6 @@ function Remover() {
   $('div#notebook-container').css('height','');
   $('div#notebook-container').css('zoom','');
 
-  $('#maincss').remove();
   $('#theme').remove();
   $('#revealcss').remove();
 
@@ -367,7 +364,7 @@ function Remover() {
   }
 
   $('div#notebook-container').children('section').remove();
-  $('.end_space').appendTo('div#notebook-container');
+  $('.end_space').appendTo('div#notebook');
 }
 
 function revealMode() {
@@ -401,6 +398,8 @@ function revealMode() {
 }
 
 function setup() {
+  $('head').append('<link rel="stylesheet" href=' + require.toUrl("./main.css") + ' id="maincss" />');
+
   IPython.toolbar.add_buttons_group([
     {
     'label'   : 'Enter/Exit Live Reveal Slideshow',

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -338,8 +338,6 @@ function Remover() {
   Reveal.configure({minScale: 1.0});
   Reveal.removeEventListeners();
   $('body').removeClass("rise-enabled");
-  $('div#site').css("height", "");
-  //$('div#maintoolbar').show();
   IPython.menubar._size_header();
 
   $('div#notebook').removeClass("reveal");
@@ -365,6 +363,7 @@ function Remover() {
 
   $('div#notebook-container').children('section').remove();
   $('.end_space').appendTo('div#notebook');
+  IPython.page.show_site();
 }
 
 function revealMode() {

--- a/livereveal/main.orig.css
+++ b/livereveal/main.orig.css
@@ -1,0 +1,146 @@
+/* Reveal-specific */
+.reveal .slides {
+  text-align: left;
+  font-size: 160%;
+}
+.reveal pre {
+  font-size: 90%;
+  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
+  overflow-y: hidden;
+  overflow-x: hidden;
+}
+.reveal section img {
+  border: 0px solid black;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0);
+  transition: none;
+}
+.reveal blockquote p:first-child, .reveal blockquote p:last-child {
+  display: inherit;
+}
+.reveal.fade {
+  opacity: 1;
+}
+.reveal .slide-number {
+  right: 3.1em;
+  bottom: 3.9em;
+  font-size: 100%;
+}
+.reveal .controls div.navigate-left,
+.reveal .controls div.navigate-left.enabled {
+  border-right-color: #727272;
+}
+.reveal .controls div.navigate-right,
+.reveal .controls div.navigate-right.enabled {
+  border-left-color: #727272;
+}
+.reveal .controls div.navigate-up,
+.reveal .controls div.navigate-up.enabled {
+  border-bottom-color: #727272;
+}
+.reveal .controls div.navigate-down,
+.reveal .controls div.navigate-down.enabled {
+  border-top-color: #727272;
+}
+.reveal .controls div.navigate-left.enabled:hover {
+  border-right-color: #dfdfdf;
+}
+.reveal .controls div.navigate-right.enabled:hover {
+  border-left-color: #dfdfdf;
+}
+.reveal .controls div.navigate-up.enabled:hover {
+  border-bottom-color: #dfdfdf;
+}
+.reveal .controls div.navigate-down.enabled:hover {
+  border-top-color: #dfdfdf;
+}
+.progress {
+  margin-bottom: 0px;
+}
+.reveal .progress span {
+  background: #727272;
+}
+.reveal .reveal-skip {
+  display: none;
+}
+.reveal .reveal-notes {
+  display: none;
+}
+
+/* Notebook-specific */
+div#notebook {
+  overflow: hidden;
+}
+div#notebook.reveal {
+  padding-top: 0px;
+}
+div#notebook-container {
+  background-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.notebook_app {
+background-color: #ffffff;
+}
+.ctb_global_show div.ctb_hideshow.ctb_show {
+  display: none;
+}
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+  border-style: none;
+}
+div.widget-area .form-control,
+div.widget-area .dropdown-menu,
+div.widget-area .btn {
+  font-size: inherit;
+}
+div.widget-area ul.dropdown-menu {
+  margin: 0px; /* cancel the settings from reveal */
+}
+.cell li {
+  line-height: 160%;
+}
+div.text_cell {
+  font-size: 160%;
+}
+div.text_cell .prompt{
+  display: none;
+}
+div.text_cell.rendered .rendered_html {
+  overflow-y: hidden;
+}
+div.prompt {
+  font-size: 90%;
+}
+div.output_prompt {
+  margin-top: 2px;
+}
+div.output_subarea {
+  margin-top: 0.05em;
+}
+.CodeMirror {
+  font-size: 100%;
+  max-width: 960px !important;  /* fix for firefox issue in IPython, 1240px */
+}
+a.anchor-link {
+  display: none;
+}
+html {
+  overflow-y: auto;
+}
+kbd {
+  padding: .1em .6em;
+  border: 1px solid #ccc;
+  font-size: 11px;
+  background-color: #f7f7f7;
+  color: #333;
+  -moz-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  -webkit-box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0 .1em;
+  text-shadow: 0 1px 0 #fff;
+  line-height: 1.4;
+  white-space: nowrap;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fulminologist",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "less": "PATH=./node_modules/.bin:$PATH lessc --autoprefix src/less/main.less livereveal/main.css",
+    "watch-less": "./node_modules/.bin/watch 'npm run less' src/less"
+  },
+  "author": "",
+  "license": "BSD",
+  "devDependencies": {
+    "less": "~2.5.0",
+    "watch": "~0.16.0",
+    "less-plugin-autoprefix": "~1.4.2",
+    "less-plugin-clean-css": "~1.5.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,18 +1,26 @@
 {
-  "name": "fulminologist",
-  "version": "0.0.0",
-  "description": "",
-  "main": "index.js",
+  "author": {
+    "name": "Damián Avila",
+    "url": "https://github.com/damianavila"
+  },
+  "description": "Edit and Present Revealjs slides in the Jupyter Notebook",
+  "devDependencies": {
+    "less": "~2.5.0",
+    "less-plugin-autoprefix": "~1.4.2",
+    "less-plugin-clean-css": "~1.5.0",
+    "watch": "~0.16.0"
+  },
+  "license": "BSD",
+  "main": "livereveal/main.js",
+  "name": "rise",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/damianavila/RISE.git"
+  },
   "scripts": {
+    "build": "npm run less",
     "less": "PATH=./node_modules/.bin:$PATH lessc --autoprefix src/less/main.less livereveal/main.css",
     "watch-less": "./node_modules/.bin/watch 'npm run less' src/less"
   },
-  "author": "",
-  "license": "BSD",
-  "devDependencies": {
-    "less": "~2.5.0",
-    "watch": "~0.16.0",
-    "less-plugin-autoprefix": "~1.4.2",
-    "less-plugin-clean-css": "~1.5.0"
-  }
+  "version": "0.3.0"
 }

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -92,7 +92,7 @@
     width: 100%;
   }
 
-  .ctb_global_show {
+  &.ctb_global_show {
     .ctb_hideshow.ctb_show { display: none; }
     .ctb_show ~ .text_cell_render { border-style: none; }
   }

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1,0 +1,175 @@
+@some-grey: #727272;
+@some-other-grey: #dfdfdf;
+
+.transition-all {
+  transition-property: all;
+  transition-duration: 0.3s;
+  transition-timing-function: ease;
+}
+
+.rise-enabled {
+  background-color: #fff;
+  .transition-all;
+
+  /* Reveal-specific */
+  .reveal {
+    &.fade {
+      .transition-all;
+      opacity: 1;
+    }
+
+    /* element-overrides */
+    pre {
+      .transition-all;
+      font-size: 90%;
+      box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
+      overflow: hidden;
+    }
+
+    section img {
+      .transition-all;
+      border: 0px solid black;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0);
+      transition: none;
+    }
+
+    blockquote {
+      p:first-child, p:last-child { display: inherit; }
+    }
+
+    .slides {
+      .transition-all;
+      text-align: left;
+      font-size: 160%;
+    }
+
+    .slide-number {
+      .transition-all;
+      right: 3.1em;
+      bottom: 3.9em;
+      font-size: 100%;
+    }
+
+    .controls {
+      .navigate-left, .navigate-left.enabled{
+        border-right-color: @some-grey;
+        &.enabled:hover{ border-right-color: @some-other-grey; }
+      }
+      .navigate-right, .navigate-right.enabled{
+        border-left-color: @some-grey;
+        &.enabled:hover{ border-left-color: @some-other-grey; }
+      }
+      .navigate-up, .navigate-up.enabled{
+        border-bottom-color: @some-grey;
+        &.enabled:hover{ border-bottom-color: @some-other-grey; }
+      }
+      .navigate-down, .navigate-down.enabled{
+        border-top-color: @some-grey;
+        &.enabled:hover{ border-top-color: @some-other-grey; }
+      }
+    }
+
+    .progress {
+      margin-bottom: 0;
+      span { background: @some-grey; }
+    }
+
+    .reveal-skip, .reveal-notes { display: none; }
+
+  } // .reveal
+
+  /* Notebook-specific */
+  #notebook { overflow: hidden; }
+
+  #notebook.reveal {
+    padding-top: 0px;
+  }
+
+  #notebook-container {
+    .transition-all;
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  .ctb_global_show {
+    .ctb_hideshow.ctb_show { display: none; }
+    .ctb_show ~ .text_cell_render { border-style: none; }
+  }
+
+  .widget-area {
+    .form-control, .dropdown-menu, .btn { font-size: inherit; }
+    .dropdown-menu { margin: 0px; /* cancel the settings from reveal */ }
+  }
+
+  .cell li {
+    .transition-all;
+    line-height: 160%;
+  }
+
+  .text_cell {
+    .transition-all;
+    font-size: 160%;
+
+    .prompt { display: none; }
+
+    &.rendered .rendered_html { overflow-y: hidden; }
+  }
+
+  .prompt {
+    .transition-all;
+    font-size: 90%;
+  }
+
+  .output_prompt {
+    .transition-all;
+    margin-top: 2px;
+  }
+
+  .output_subarea {
+    .transition-all;
+    margin-top: 0.05em;
+  }
+
+  .CodeMirror {
+    .transition-all;
+    font-size: 100%;
+    max-width: 960px !important;  /* fix for firefox issue in IPython, 1240px */
+  }
+
+  a.anchor-link { display: none; }
+
+  html { overflow-y: auto; }
+
+  .dialog kbd {
+    padding: .1em .6em;
+    border: 1px solid #ccc;
+    font-size: 11px;
+    background-color: #f7f7f7;
+    color: #333;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+    border-radius: 3px;
+    display: inline-block;
+    margin: 0 .1em;
+    text-shadow: 0 1px 0 #fff;
+    line-height: 1.4;
+    white-space: nowrap;
+  }
+
+  #header {
+    .transition-all;
+    top: -200px;
+    opacity: 0;
+  }
+
+  #site {
+    .transition-all;
+    height: 100%;
+  }
+  #ipython-main-app { position: static; }
+} //.reveal-enabled
+
+#header {
+  .transition-all;
+  opacity: 1;
+  top: 0px;
+}

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -3,7 +3,7 @@
 
 .transition-all {
   transition-property: all;
-  transition-duration: 0.3s;
+  transition-duration: 0.2s;
   transition-timing-function: ease;
 }
 
@@ -89,11 +89,20 @@
     .transition-all;
     background-color: transparent;
     box-shadow: none;
+    width: 100%;
   }
 
   .ctb_global_show {
     .ctb_hideshow.ctb_show { display: none; }
     .ctb_show ~ .text_cell_render { border-style: none; }
+  }
+
+  .celltoolbar {
+    height: inherit;
+    select, .btn {
+      height: inherit;
+      font-size: inherit;
+    }
   }
 
   .widget-area {
@@ -102,12 +111,10 @@
   }
 
   .cell li {
-    .transition-all;
     line-height: 160%;
   }
 
   .text_cell {
-    .transition-all;
     font-size: 160%;
 
     .prompt { display: none; }
@@ -172,4 +179,12 @@
   .transition-all;
   opacity: 1;
   top: 0px;
+}
+
+#notebook-container {
+  .transition-all;
+}
+
+#notebook {
+  .transition-all;
 }


### PR DESCRIPTION
Jumping between slide and notebook modes is a little jarring.

This adds some transitions, maybe too many, to the transition between the modes.

> screenshot
![](http://i.imgur.com/EUcy4PI.gif)

To achieve this, it needs a few things:
- the styles have to be loaded when modes change: this means the CSS has to be added prior to switching modes, and has to be there when you leave...
  - thus, the styles get added at extension setup time...
- to keep the styles from firing all the time against important elements like `#site`, the `body` is given a `rise-enabled` class, and all of the styles are conditional off being inside that
  - to do this, I have ported the CSS to LESS rather than putting `.rise-enabled` in front of every directive
- this also shortens the code some, as CSS not directly manipulated by reveal can be done in CSS

## tool creep
I hate tool creep as much as the next guy, but i think it makes sense in this case. LESS is a good choice because of the upstream (though with phosphor, i guess we'll have to start contending with stylus, too?). I've used `watch` to let us have live compiling without gulp/grunt.

Once the die is cast, however, things like bower may follow. even if the bower components still get checked in, they could be checked in on a `dist`-like folder so that we're not tracking all _n_000 reveal files.