### PR TITLE
Don't explicitly supply config dir to enable extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ To install this nbextension, simply run ``python setup.py install`` from the
 *RISE* repository.
 
 The setup script will respect your `JUPYTER_CONFIG_DIR` environment variable to
-enable the extension.
+enable the extension. So to enable the extension for a non-default config
+directory, run:
+
+    JUPYTER_CONFIG_DIR=path/to/config/ python setup.py install
 
 ## RISE talk
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 To install this nbextension, simply run ``python setup.py install`` from the
 *RISE* repository.
 
+The setup script will respect your `JUPYTER_CONFIG_DIR` environment variable to
+enable the extension.
+
 ## RISE talk
 
 My talk about **RISE** at *SciPy 2014* (click on the image to see it):

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,16 @@
 import os
 from notebook.nbextensions import install_nbextension
 from notebook.services.config import ConfigManager
-from jupyter_core.paths import jupyter_config_dir as get_jupyter_config_dir
 
 livereveal_dir = os.path.join(os.path.dirname(__file__), 'livereveal')
-jupyter_config_dir = get_jupyter_config_dir()
 
-def install(config_dir, use_symlink=False, enable=True):
+def install(use_symlink=False, enable=True):
     # Install the livereveal code.
     install_nbextension(livereveal_dir, symlink=use_symlink,
                         overwrite=use_symlink, user=True)
 
     if enable:
-        cm = ConfigManager(config_dir=config_dir)
+        cm = ConfigManager()
         cm.update('notebook', {"load_extensions": {"livereveal/main": True}})
 
 def main():
@@ -25,17 +23,14 @@ def main():
                                        help='additional help')
 
     install_parser = subparsers.add_parser('install')
-    install_parser.add_argument('--jupyter-config-dir', action='store', default=jupyter_config_dir,
-                                help="The path of the Jupyter config dir to use.")  
     install_parser.add_argument('--develop', action='store_true',
                                 help="Install livereveal  as a symlink to the source.")
     install_parser.add_argument('--no-enable', action='store_true',
-                                help="Install but don't enable the extension.")                                
-    
+                                help="Install but don't enable the extension.")
+
     args = parser.parse_args(sys.argv[1:])
 
-    install(config_dir=args.jupyter_config_dir,
-            use_symlink=args.develop,
+    install(use_symlink=args.develop,
             enable=(not args.no_enable))
 
 


### PR DESCRIPTION
It was changing the config in the wrong directory - see jupyter/notebook#251 for details.

If people want to install with different config directories, they should set the JUPYTER_CONFIG_DIR environment variable. ConfigManager will respect this automatically, without you needing to do anything.

i.e. instead of `python setup.py install --jupyter-config-dir foo/`, get people to do:

    JUPYTER_CONFIG_DIR=foo/ python setup.py install