### PR TITLE
Workaround to remove extra fade class when using fade transition

### DIFF
--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -358,6 +358,8 @@ function Remover() {
   IPython.menubar._size_header();
 
   $('div#notebook').removeClass("reveal");
+  // woekaround to fix fade class conflicting between notebook and reveal css...
+  if ($('div#notebook').hasClass('fade')) { $('div#notebook').removeClass("fade"); };
   $('div#notebook-container').removeClass("slides");
   $('div#notebook-container').css('width','');
   $('div#notebook-container').css('height','');


### PR DESCRIPTION
Ping

@mcrovella @ndawe

Finally have a clue about what was happening with this comment... https://github.com/damianavila/RISE/issues/145#issuecomment-145294598

Please test it and report back... this fix the issue for me.