### PR TITLE
Closes #188: calling Reveal.sync after output is generated

### DIFF
--- a/rise/static/main.css
+++ b/rise/static/main.css
@@ -221,7 +221,7 @@
   font-size: 11px;
   background-color: #f7f7f7;
   color: #333;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
   border-radius: 3px;
   display: inline-block;
   margin: 0 .1em;

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -11,9 +11,10 @@
 define([
         'require',
         'jquery',
+        'underscore',
         'base/js/utils',
         'services/config',
-], function(require, $, utils, configmod) {
+], function(require, $, _, utils, configmod) {
 
 function configSlides() {
   /*
@@ -480,6 +481,23 @@ function setup() {
   };
   $(document).keydown(document_keydown);
 }
+
+function mutationHandler(mutationRecords) {
+  mutationRecords.forEach(function(mutation) {
+    if (mutation.addedNodes && mutation.addedNodes.length) {
+      Reveal.sync();
+    }
+  });
+}
+
+var $output = $(".output");
+var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+var outputObserver = new MutationObserver(mutationHandler);
+var observerConfig = { childList: true, characterData: false, attributes: false, subtree: false };
+
+$output.each(function () {
+  outputObserver.observe(this, observerConfig);
+});
 
 setup.load_ipython_extension = setup;
 


### PR DESCRIPTION
Closes #188  
This makes Reveal.js to vertically center slides considering outputs generated on the fly.