### PR TITLE
Add support for headers and footers on each slide

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -32,6 +32,10 @@ function configSlides() {
       slideNumber: true,
       start_slideshow_at: 'beginning',
       scroll: false,
+      headerLeft: '',
+      headerRight: '',
+      footerLeft: '',
+      footerRight: '',
   };
 
   var config_section = new configmod.ConfigSection('livereveal',
@@ -301,6 +305,54 @@ function Revealer(config) {
     });
 
     setupOutputObserver();
+
+    // Header and footer
+    var headerFooter = $('<div/>').attr('id', 'livereveal-header');
+      
+    var headerLeft = config.get_sync('headerLeft');
+    if (headerLeft !== "") {
+        headerFooter.append($('<div/>')
+            .attr('id','livereveal-header-left')
+            .css('position','absolute')
+            .css('top', '0%')
+            .css('left', '0%')
+            .html(headerLeft));
+    }
+
+    var headerRight = config.get_sync('headerRight');
+    if (headerRight !== "") {
+        headerFooter.append($('<div/>')
+            .attr('id','livereveal-header-right')
+            .css('position','absolute')
+            .css('top', '0%')
+            .css('right', '0%')
+            .html(headerRight));
+    }
+
+    var footerLeft = config.get_sync('footerLeft');
+    if (footerLeft !== "") {
+        headerFooter.append($('<div/>')
+            .attr('id','livereveal-footer-left')
+            .css('position','absolute')
+            .css('bottom', '0%')
+            .css('left', '0%')
+            .html(footerLeft));
+    }
+
+    var footerRight = config.get_sync('footerRight');
+    if (footerRight !== "") {
+        headerFooter.append($('<div/>')
+            .attr('id','livereveal-footer-right')
+            .css('position','absolute')
+            .css('bottom', '0%')
+            .css('right', '0%')
+            .html(footerRight));
+    }
+
+    if (headerFooter.html() !== "") {
+        $('#notebook_panel').append(headerFooter);
+    }
+
   });
 }
 
@@ -448,6 +500,8 @@ function Remover(config) {
   $('.slide-number').remove();
   $('.state-background').remove();
   $('.pause-overlay').remove();
+
+  $('#livereveal-header').remove();
 
   var cells = IPython.notebook.get_cells();
   for(var i in cells){


### PR DESCRIPTION
Hi,

I needed a way to add consistent headers and footers to my slides. The approach is not particularly elegant, but works well enough for me. I've just added four configuration options to the metadata where I can specify html to be inserted by Revealer() and removed by Remover():

````
  "livereveal": {
    "headerLeft": "`header left",
    "headerRight": "header right",
    "footerLeft": "footer left",
    "footerRight": "footer right"
  },
```

I'm not sure if I chose the correct div to append the headers and footers to, but they end up where I want them...