### PR TITLE
Hide Input/Output number when presenting

### DIFF
--- a/rise/static/main.css
+++ b/rise/static/main.css
@@ -165,13 +165,11 @@
 .rise-enabled .text_cell {
   font-size: 160%;
 }
-.rise-enabled .text_cell .prompt {
-  display: none;
-}
 .rise-enabled .text_cell.rendered .rendered_html {
   overflow-y: hidden;
 }
 .rise-enabled .prompt {
+  display: none;
   -webkit-transition-property: all;
           transition-property: all;
   -webkit-transition-duration: 0.2s;


### PR DESCRIPTION
I don't think they actually add anything to the content. And by the way `nb-present` does that too.
