### PR TITLE
Pass the "center" option to Reveal.configure() (#166)

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -32,6 +32,7 @@ function configSlides() {
       slideNumber: true,
       start_slideshow_at: 'beginning',
       scroll: false,
+      center: true
   };
 
   var config_section = new configmod.ConfigSection('livereveal',
@@ -248,6 +249,7 @@ function Revealer(config) {
     transition: Reveal.getQueryHash().transition || config.get_sync('transition'),
 
     slideNumber: config.get_sync('slideNumber'),
+    center: config.get_sync('center'),
 
     //parallaxBackgroundImage: 'https://raw.github.com/damianavila/par_IPy_slides_example/gh-pages/figs/star_wars_stormtroopers_darth_vader.jpg',
     //parallaxBackgroundSize: '2560px 1600px',


### PR DESCRIPTION
The `center` option was simply omitted from `Reveal.configure()`, and thus had no effect in the notebook metadata or `ConfigManager.update()`.
