### PR TITLE
Set help and exit buttons in foreground with z-index

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -393,6 +393,7 @@ function buttonHelp() {
         .css('bottom','0.5em')
         .css('left','0.6em')
         .css('opacity', '0.6')
+        .css('z-index', '30')
         .click(
             function(){
                 KeysMessager();
@@ -411,6 +412,7 @@ function buttonExit() {
         .css('top','0.5em')
         .css('left','0.48em')
         .css('opacity', '0.6')
+        .css('z-index', '30')
         .click(
             function(){
                 revealMode('simple', 'zoom');


### PR DESCRIPTION
Add z-index to CSS of help and exit buttons so that they are always in the foreground, as suggested in https://github.com/damianavila/RISE/issues/233

Before:
<img width="190" alt="screen shot 2016-11-02 at 17 00 22" src="https://cloud.githubusercontent.com/assets/802153/19938779/1b8547fc-a11e-11e6-9767-9df0d90f71a4.png">

After:
<img width="172" alt="screen shot 2016-11-02 at 16 59 33" src="https://cloud.githubusercontent.com/assets/802153/19938791/27a86636-a11e-11e6-8d93-4cc1217ab523.png">

Of course it is a question of preference, except that if you do not set the `z-index` of the buttons, they will be rendered behind the cells of code, but in front of the rendered markdown, which is not very consistent...