### PR TITLE
fix for correct invokation of sed on the MAC platform when running

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build-css": "npm run less",
     "build-reveal": "cp -r ./node_modules/reveal.js rise/static/reveal.js",
-    "reset-reveal": "sed -i '11 s_^_\/*_' rise/static/reveal.js/css/reveal.css",
+    "reset-reveal": "sed -i.upstream '11 s_^_\/*_' rise/static/reveal.js/css/reveal.css",
     "clean-reveal": "rm -r rise/static/reveal.js",
     "less": "PATH=./node_modules/.bin:$PATH lessc --autoprefix src/less/main.less rise/static/main.css",
     "watch-less": "./node_modules/.bin/watch 'npm run less' src/less"


### PR DESCRIPTION
npm run reset-reveal
as per the development guide
https://github.com/damianavila/RISE#development

this was touched on in #282