### PR TITLE
Add consistent sidebar for all doc pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -89,8 +89,22 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'show_related': True,
+    'description': 'RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension',
+    'github_user': 'damianavila',
+    'github_repo': 'RISE',
+}
 
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',
+        'sourcelink.html',
+        'searchbox.html'
+    ]
+}
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
This PR adds a title, description, repo badge to the docs sidebar. The sidebar persists on all pages.

Congrats on the new release @damianavila :tada: