### PR TITLE
Made the toolbar button narrower, now it only says 'RISE Slideshow'

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -928,19 +928,16 @@ define([
   function setup() {
     $('head').append('<link rel="stylesheet" href=' + require.toUrl("./main.css") + ' id="maincss" />');
 
-    // use same label in button and shortcut
-    var rise_label = 'Enter/Exit RISE Slideshow';
-
     // create button
     Jupyter.toolbar.add_buttons_group([{
-      label   : rise_label,
+      label   : 'RISE Slideshow',
       icon    : 'fa-bar-chart-o',
       callback: revealMode,
       id      : 'RISE'
     }]);
     // define the slideshow action
     var slideshow_action = {
-      help    : rise_label,
+      help    : 'Enter/Exit RISE Slideshow',
       handler : revealMode,
     }
     // register action    


### PR DESCRIPTION
Here is a narrower toolbar button, fixes #319 .

![screen shot 2017-11-19 at 22 15 33](https://user-images.githubusercontent.com/879300/32995605-3a40972e-cd77-11e7-8962-009b3dfdb573.png)

Should it be still leaner? With maybe just the word "Slideshow" on it, or a verb like "Present", or just the icon, coherent with most of the other buttons? Personally this button has become important to me (thank you for amazing extension!), so I would enjoy having a word in the button.