### PR TITLE
Make the output observer aware of the scrolling needs

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -299,11 +299,12 @@ define([
    * This fixes issue #188: https://github.com/damianavila/RISE/issues/188
    */
   var outputObserver = null;
-  function setupOutputObserver() {
+  function setupOutputObserver(config) {
     function mutationHandler(mutationRecords) {
       mutationRecords.forEach(function(mutation) {
         if (mutation.addedNodes && mutation.addedNodes.length) {
           Reveal.sync();
+          setScrollingSlide(config);
         }
       });
     }
@@ -494,7 +495,7 @@ define([
               });
 
               // Sync when an output is generated.
-              setupOutputObserver();
+              setupOutputObserver(config);
 
               // Setup the starting slide
               setStartingSlide(selected_slide, config);

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -256,6 +256,7 @@ define([
         // Start from the beginning
         Reveal.slide(0, 0);
       }
+      setScrollingSlide(config);
     });
 
   }


### PR DESCRIPTION
Fixes the problem outlined here: https://github.com/binder-examples/jupyter-rise/issues/1

cc @choldgraf 