### PR TITLE
Added note about PDF export for slides using JS

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -83,7 +83,7 @@ Note that you need to remove the ``#`` at the end. The page will render the slid
   + Enable the Background graphics option.
   + Click Save.
   
-Note that if you are using JavaScript-based packages like [Bokeh](http://bokeh.pydata.org) in your slides, you will need to ensure that any cells that define JS code used by other cells are *not* skipped by RISE.  For instance, Bokeh plots will only be visible in the PDF output if you include the cell containing ``output_notebook()`` (or ``hv.extension()`` if using Bokeh via [HoloViews](http://holoviews.org)), even if the live RISE presentation works fine when skipping those cells.
+Note that if you are using JavaScript-based packages like [Bokeh](http://bokeh.pydata.org) in your slides, you will need to ensure that any cells that define JS code used by other cells are *not* skipped by RISE.  For instance, Bokeh plots will only be visible in the PDF output if you include the cell containing ``output_notebook()`` (or ``hv.extension()`` if using Bokeh via [HoloViews](http://holoviews.org)), even if the live RISE presentation works fine when skipping those cells. You can use the `Notes` slide type for that cell if you want it to be omitted from the RISE slideshow but included in HTML or PDF output. 
 
 Using decktape
 ++++++++++++++

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -82,6 +82,8 @@ Note that you need to remove the ``#`` at the end. The page will render the slid
   + Change the Margins to None.
   + Enable the Background graphics option.
   + Click Save.
+  
+Note that if you are using JavaScript-based packages like [Bokeh](http://bokeh.pydata.org) in your slides, you will need to ensure that any cells that define JS code used by other cells are *not* skipped by RISE.  For instance, Bokeh plots will only be visible in the PDF output if you include the cell containing ``output_notebook()`` (or ``hv.extension()`` if using Bokeh via [HoloViews](http://holoviews.org)), even if the live RISE presentation works fine when skipping those cells.
 
 Using decktape
 ++++++++++++++


### PR DESCRIPTION
Addresses issue #350, i.e. that Bokeh plots fail to show up in PDF output if the cell containing the BokehJS is skipped by RISE.