### PR TITLE
patch to address #358 - (together with a micro-change that belongs in #371)

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -409,17 +409,18 @@ At this point you need to be aware that:
 
 Here are the Jupyter actions registered by RISE:
 
-    action name             key      behaviour
+    action name                key      behaviour
     ------------------------------------------------------
-    RISE:slideshow         alt-r  enter/exit RISE Slideshow
-    RISE:smart-exec               execute cell, move to the next if on same slide
-    RISE:toggle-slide     shift-i (un)set current cell as a Slide cell
-    RISE:toggle-subslide  shift-u (un)set current cell as a Sub-slide cell
-    RISE:toggle-fragment  shift-f (un)set current cell as a Fragment cell
-    RISE:toggle-note              (un)set current cell as a Note cell
-    RISE:toggle-skip              (un)set current cell as a Skip cell
-    RISE:render-all-cells         render all cells (all cells go to command mode)
-    RISE:edit-all-cells           edit all cells (all cells go to edit mode)
+    RISE:slideshow            alt-r  enter/exit RISE Slideshow
+    RISE:smart-exec                  execute cell, move to the next if on same slide
+    RISE:toggle-slide        shift-i (un)set current cell as a Slide cell
+    RISE:toggle-subslide     shift-u (un)set current cell as a Sub-slide cell
+    RISE:toggle-fragment     shift-f (un)set current cell as a Fragment cell
+    RISE:toggle-notes                (un)set current cell as a Note cell
+    RISE:toggle-skip                 (un)set current cell as a Skip cell
+    RISE:render-all-cells            render all cells (all cells go to command mode)
+    RISE:edit-all-cells              edit all cells (all cells go to edit mode)
+    RISE:rise-nbconfigurator shift-c open the nbconfigurator pane in another tab
 
 Some, but not all, come bound to default keyboard shortcuts. There are
 2 ways you can change the bindings

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -72,6 +72,8 @@ define([
         'toggle-slide': 'shift-i',
         'toggle-subslide': 'shift-u',
         'toggle-fragment': 'shift-f',
+        // this can be helpful
+        'rise-nbconfigurator': 'shift-c',
         // unassigned by default
         'toggle-note': '',
         'toggle-skip': '',
@@ -931,10 +933,24 @@ define([
                      },
                      "edit-all-cells", "RISE");
 
+    // because the `Edit Keyboard Shortcuts` utility does not mention the
+    // actions prefix (i.e. 'RISE' in our case), we choose to make these two
+    // action names start with `rise-` even if it's a bit redundant.
+
+    // define an action that goes to the nbconfigurator page for rise
+    let nbconfigurator = function() {
+      let url = "/nbextensions/?nbextension=rise/main";
+      window.open(url, '_blank');
+    }
+
+    actions.register({ help: 'open the nbconfigurator page for RISE',
+                       handler: nbconfigurator},
+                     "rise-nbconfigurator", "RISE");
+
     // mostly for debug / information
-    actions.register({ help   : 'show RISE config in console',
+    actions.register({ help   : 'output RISE configuration in console, for debugging mostly',
                        handler: showConfig},
-                     "show-config", "RISE");
+                     "rise-dump-config", "RISE");
 
   }
 
@@ -1007,6 +1023,7 @@ define([
       let shortcut = shortcuts[action_name];
       // ignore if shortcut is set to an empty string
       if (shortcut) {
+//        console.log(`RISE: adding shortcut ${shortcut} for ${action_name}`)
         Jupyter.notebook.keyboard_manager.command_shortcuts.add_shortcut(
           shortcut, `RISE:${action_name}`)
       }

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -129,6 +129,12 @@ Parameters:
   description: <code>rise.shortcuts.edit-all-cells</code> shortcut to put all cells in edit mode
   input_type: hotkey
   default: none
+- name: rise.shortcuts.rise-nbconfigurator
+  description: >
+    <code>rise.shortcuts.rise-nbconfigurator</code> shortcut to open the nbconfigurator
+    pane for the RISE extension in a new tab (or window, depending on your browser config).
+  input_type: hotkey
+  default: shift-c
 
 #
 # passed to reveal as-is


### PR DESCRIPTION
* define action RISE:rise-nbconfigurator
* bind it by default to shift-c
* corresponding addition in rise.yaml
* as well as in customization doc
* also contains one remaining change in the doc about toggle-note vs toggle-notes