### PR TITLE
Make the configurator yaml file compatible with notebook 5.x

### DIFF
--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -4,7 +4,7 @@
 # that they reflect the defaults that are hardwired in main.js
 #
 Type: Jupyter Notebook Extension
-Compatibility: jupyter-4.3, jupyter-notebook-5.4
+Compatibility: 5.x
 Name: RISE
 Main: main.js
 Description: "Turn your Jupyter Notebooks into a live presentation (slideshow)"


### PR DESCRIPTION
Simple change so the configurator renders RISE by default when you use notebook 5.5 and 5.6.