### PR TITLE
Adding 't' to help section in UI.

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -689,6 +689,7 @@ define([
           "<li><kbd>Home</kbd>: First slide</li>" +
           "<li><kbd>End</kbd>: Last slide</li>" +
           "<li><kbd>w</kbd>: Toggle overview mode</li>" +
+          "<li><kbd>t</kbd>: Toggle presenter mode (with notes)</li>" +
           "<li><kbd>,</kbd>: Toggle help and exit buttons</li>" +
           "<li><kbd>.</kbd> or <kbd>/</kbd>: black screen</li>" +
           "<li><strong>Not so useful:</strong>" +


### PR DESCRIPTION
After finding the breadcrumbs that led me to this PR, I found that the shortcut added in https://github.com/damianavila/RISE/pull/412 wasn't added to the help text in the UI. Wasn't quite sure how to word it so it wouldn't be too long, but also be helpful. 

Let me know if you want the wording changed in some way. 