### PR TITLE
close #434

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -414,9 +414,9 @@ Here are the Jupyter actions registered by RISE:
     RISE:slideshow            alt-r  enter/exit RISE Slideshow
     RISE:smart-exec                  execute cell, move to the next if on same slide
     RISE:toggle-slide        shift-i (un)set current cell as a Slide cell
-    RISE:toggle-subslide     shift-u (un)set current cell as a Sub-slide cell
-    RISE:toggle-fragment     shift-f (un)set current cell as a Fragment cell
-    RISE:toggle-notes                (un)set current cell as a Note cell
+    RISE:toggle-subslide     shift-b (un)set current cell as a Sub-slide cell
+    RISE:toggle-fragment     shift-g (un)set current cell as a Fragment cell
+    RISE:toggle-notes                (un)set current cell as a Notes cell
     RISE:toggle-skip                 (un)set current cell as a Skip cell
     RISE:render-all-cells            render all cells (all cells go to command mode)
     RISE:edit-all-cells              edit all cells (all cells go to edit mode)

--- a/doc/customize.md
+++ b/doc/customize.md
@@ -271,9 +271,14 @@ RISE can be customized in a lot of ways. As of RISE version 5.3, you can:
 
 ### The configurator
 
-You may need to install a separate module:
+You may need to install and enable additional modules, refer to [this github
+repo](https://github.com/ipython-contrib/jupyter_contrib_nbextensions) for more
+details on Jupyter notebook extensions.
 
-    pip3 install jupyter-nbextensions-configurator
+In a nutshell:
+
+    pip3 install jupyter_contrib_nbextensions
+    jupyter contrib nbextension install
 
 or
 

--- a/doc/dev/develop.md
+++ b/doc/dev/develop.md
@@ -30,7 +30,7 @@ Essentially you will need:
 **Notes**:
 
 * this is all that is needed at that stage
-* later on you might want to take a look at `package.json` that has finer-grained targets, that the `build` target groups for your conevnience
+* later on you might want to take a look at `package.json` that has finer-grained targets, that the `build` target groups for your convenience
 * in particular, if you only need to redo css, you can do `npm run build-css`
 * also note that you can remove `reveal.js` from the static folder with `npm run clean-reveal`.
 

--- a/doc/dev/develop.md
+++ b/doc/dev/develop.md
@@ -27,11 +27,12 @@ Essentially you will need:
 
     npm run build
 
-To remove `reveal.js` from the static folder you can use `npm run clean-reveal`.
+**Notes**:
 
-**Step 3.** Build the CSS assets:
-
-    npm run build-css
+* this is all that is needed at that stage
+* later on you might want to take a look at `package.json` that has finer-grained targets, that the `build` target groups for your conevnience
+* in particular, if you only need to redo css, you can do `npm run build-css`
+* also note that you can remove `reveal.js` from the static folder with `npm run clean-reveal`.
 
 ### Install RISE in developer mode
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -26,7 +26,7 @@ You can choose between the following types:
   slide; it will not show up right away, you will need to press Space
   one more time to see it.
 
-* **skip**: this cell are ignored altogether in *reveal* mode,
+* **skip**: this cell is ignored altogether in *reveal* mode,
 it will not appear either in the main view, nor in the speaker view.
 
 * **notes**: similarly, this cell is marked to be discarded from
@@ -46,8 +46,8 @@ according to your needs:
 
 -   `Alt-r`, \"Enter/Exit Live Reveal Slideshow\"
 -   `Shift-i`, Toggle slide
--   `Shift-u`, Toggle subslide
--   `Shift-f`, Toggle fragment
+-   `Shift-b`, Toggle subslide
+-   `Shift-g`, Toggle fragment
 
 ## Running a slideshow
 

--- a/examples/README.css
+++ b/examples/README.css
@@ -1,0 +1,13 @@
+/*
+ * this is loaded together with README.ipynb
+ * because it's named the same with css extension
+ */
+
+ /* ***** just a stupid setting that you cannot miss ***** */
+ div.cell.code_cell.rendered {
+     border-radius: 0px 0px 30px 0px;
+ }
+
+div.input_area {
+    border-radius: 0px 0px 25px 0px;
+}

--- a/examples/README.css
+++ b/examples/README.css
@@ -3,10 +3,10 @@
  * because it's named the same with css extension
  */
 
- /* ***** just a stupid setting that you cannot miss ***** */
- div.cell.code_cell.rendered {
-     border-radius: 0px 0px 30px 0px;
- }
+/* not very useful, but an OBVIOUS setting that you cannot miss */
+div.cell.code_cell.rendered {
+    border-radius: 0px 0px 30px 0px;
+}
 
 div.input_area {
     border-radius: 0px 0px 25px 0px;

--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -265,7 +265,7 @@
     "or, in command mode, use keyboard shortcuts\n",
     "\n",
     "* `shift-i` : toggle slide\n",
-    "* `shift-u` : toggle subslide\n",
+    "* `shift-b` : toggle subslide\n",
     "* `shift-g` : toggle fragment"
    ]
   },

--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -214,6 +214,46 @@
     }
    },
    "source": [
+    "# notes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "if you now press `t` you should see a second window open, with a presenter view, that shows *Notes* cells - that won't show up in the main slides."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "notes"
+    }
+   },
+   "source": [
+    "this is an example of a *Notes* cell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "source": [
+    "next, we'll cover how to tag cells as *Slide*, *SubSlide*, *Fragment* or *Notes*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
     "# how to create slideshows"
    ]
   },
@@ -320,11 +360,13 @@
    "source": [
     "in order for a binder-hosted notebook to start in slideshow mode, you need to have the following tag set in the notebook metadata:\n",
     "\n",
+    "```javascript        \n",
     "    ...\n",
     "    \"rise\": {\n",
     "        \"autolaunch\": true\n",
     "    }\n",
-    "    ..."
+    "    ...\n",
+    "```"
    ]
   },
   {
@@ -338,6 +380,39 @@
     "you can edit the notebook metadata from the `edit` menu, submenu `edit notebook metadata`\n",
     "\n",
     "note finally that the `rise` key in this json file used to be named `livereveal`. the latter is still honored, but the former takes precedence, and it is recommended to use only `rise` from now on"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# chalkboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "as an option, you can turn on the *chalkboard* reveal plugin, that manifests itself with 2 extra buttons in the lower left area, that let you add free drawings on your slides"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "this option is turned on, in the notebook metadata again, with:\n",
+    "\n",
+    "```javascript\n",
+    "    ...\n",
+    "    \"rise\": {\n",
+    "      \"enable_chalkboard\": true\n",
+    "    }\n",
+    "    ...\n",
+    "```"
    ]
   }
  ],

--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -358,11 +358,13 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   },
   "rise": {
    "autolaunch": true,
-   "enable_chalkboard": true
+   "enable_chalkboard": true,
+   "theme": "sky",
+   "transition": "cube"
   }
  },
  "nbformat": 4,

--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "# Turn your notebooks into slideshows"
+    "## turn your notebooks into slideshows"
    ]
   },
   {
@@ -19,7 +19,7 @@
     }
    },
    "source": [
-    "Press `Space` to proceed"
+    "press `Space` to proceed"
    ]
   },
   {
@@ -30,7 +30,7 @@
     }
    },
    "source": [
-    "You can write a regular Jupyter notebook, with the usual mix of markdown and code cells (keep on pressing `Space`)"
+    "you can write a regular Jupyter notebook, with the usual mix of markdown and code cells (keep on pressing `Space`)"
    ]
   },
   {
@@ -42,7 +42,7 @@
     }
    },
    "source": [
-    "In code cells you press `Shift-Enter` as usual to evaluate your code (but for now press `Space` again)"
+    "in code cells you press `Shift-Enter` as usual to evaluate your code (but for now press `Space` again)"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But apart from that, `Space` is your friend"
+    "but apart from that, `Space` is your friend"
    ]
   },
   {
@@ -79,7 +79,7 @@
     }
    },
    "source": [
-    "You're in a browser, so remember that you can always use smaller / larger fonts with keyboard shortcuts like `Alt +` and `Alt -` or similar."
+    "you're in a browser, so remember that you can always use smaller / larger fonts with keyboard shortcuts like `Alt +` and `Alt -` or similar"
    ]
   },
   {
@@ -140,16 +140,16 @@
     }
    },
    "source": [
-    "# The RISE notebook extension"
+    "# the RISE notebook extension"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All this is achieved through the RISE notebook extension\n",
+    "all this is achieved through the RISE notebook extension\n",
     "\n",
-    "See full documentation at http://rise.readthedocs.io/"
+    "see full documentation at http://rise.readthedocs.io/"
    ]
   },
   {
@@ -160,21 +160,22 @@
     }
    },
    "source": [
-    "# Thanks to reveal.js"
+    "# thanks to reveal.js"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [underlying tool is reveal.js](https://revealjs.com/), and it supports a lot of cool features."
+    "the [underlying tool is reveal.js](https://revealjs.com/), and it supports a lot of cool features."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For example you can organize your show into\n",
+    "for example you can organize your show into\n",
+    "\n",
     "* slides (left to right)\n",
     "* subslides (top to bottom)\n",
     "* fragments (stops inside a slide)"
@@ -184,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You do not need to worry, just press `Space` to proceed along the main line."
+    "you do not need to worry, just press `Space` to proceed along the main line"
    ]
   },
   {
@@ -195,14 +196,14 @@
     }
    },
    "source": [
-    "For example this is a subslide; observe the cursor in the bottom right corner"
+    "for example this is a subslide; observe the cursor in the bottom right corner"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you press `Shift-Space` - here or anywhere else - you will go backwards, so here it would be up."
+    "if you press `Shift-Space` - here or anywhere else - you will go backwards, so here it would be up"
    ]
   },
   {
@@ -213,14 +214,14 @@
     }
    },
    "source": [
-    "# How to create slideshows"
+    "# how to create slideshows"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 1: enable slideshow cell toolbar"
+    "### step 1: enable slideshow cell toolbar"
    ]
   },
   {
@@ -239,7 +240,7 @@
     }
    },
    "source": [
-    "## Step 2:  add appropriate tag to each cell"
+    "### step 2:  add appropriate tag to each cell"
    ]
   },
   {
@@ -277,24 +278,66 @@
     }
    },
    "source": [
-    "# Publishing on binder"
+    "# CSS"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order for a binder-hosted notebook to start in slideshow mode, you need to have the following tag set in the notebook metadata:\n",
+    "2 files are loaded without the need for configuring\n",
+    "\n",
+    "* `rise.css` in the current directory\n",
+    "* `README.css` for this notebook because it is called `README.ipynb`\n",
+    "\n",
+    "if that works then the cell below has a large border width and a big south-east border-radius"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sample code cell\n",
+    "message = \"my look is changed by both rise.css and README.css\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# publishing on binder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "in order for a binder-hosted notebook to start in slideshow mode, you need to have the following tag set in the notebook metadata:\n",
     "\n",
     "    ...\n",
     "    \"rise\": {\n",
-    "            \"autolaunch\": true\n",
-    "            }\n",
-    "    ...\n",
+    "        \"autolaunch\": true\n",
+    "    }\n",
+    "    ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "you can edit the notebook metadata from the `edit` menu, submenu `edit notebook metadata`\n",
     "\n",
-    "You can edit the notebook metadata from the `Edit` menu, submenu `Edit notebook metadata`.\n",
-    "\n",
-    "Note finally that the `rise` key in this JSON file used to be named `livereveal`. The latter is still honored, but the former takes precedence, and it is recommended to use only `rise` from now on."
+    "note finally that the `rise` key in this json file used to be named `livereveal`. the latter is still honored, but the former takes precedence, and it is recommended to use only `rise` from now on"
    ]
   }
  ],
@@ -317,7 +360,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.7.0"
   },
-  "livereveal": {
+  "rise": {
    "autolaunch": true,
    "enable_chalkboard": true
   }

--- a/examples/header-footer.ipynb
+++ b/examples/header-footer.ipynb
@@ -55,7 +55,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.4"
   },
-  "livereveal": {
+  "rise": {
    "autolaunch": true,
    "backimage": "mybackimage.png",
    "footer": "<h3>world</h3>",

--- a/examples/overlay.ipynb
+++ b/examples/overlay.ipynb
@@ -140,7 +140,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.4"
   },
-  "livereveal": {
+  "rise": {
    "autolaunch": true,
    "overlay": "<div class='myheader'><h2>my company</h2></div><div class='myfooter'><h2>the date</h2></div>"
   }

--- a/examples/rise.css
+++ b/examples/rise.css
@@ -49,7 +49,7 @@ div.plan-container {
     grid-template-columns: 50% 50%;
 }
 
-/* something big and stupid again just to outline
+/* something big and obvious again just to outline
    that this file is actually loaded */
 
 div.cell.code_cell.rendered, div.input_area {

--- a/examples/rise.css
+++ b/examples/rise.css
@@ -1,12 +1,57 @@
-/*
- * this is loaded only because it's named rise.css in the current directory
+/* this goes with my global default setting
+ * that has rise use reveal's theme sky
  */
+.reveal {
+    font-family: "Quicksand", sans-serif;
+}
 
- /* ***** just a stupid setting that you cannot miss ***** */
- div.cell.code_cell.rendered {
-     border-radius: 0px 0px 30px 0px;
- }
+.reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6 {
+    text-transform: initial;   /* sky.css says uppercase */
+    letter-spacing: initial ;  /* sky.css says -0.08em */
+}
 
-div.input_area {
-    border-radius: 0px 0px 25px 0px;
+body.rise-enabled .reveal ol, body.rise-enabled .reveal dl, body.rise-enabled .reveal ul {
+    margin-left: 0.1em;
+    margin-top: 0.2em;
+}
+
+.reveal .rendered_html h1:first-child,
+.reveal .rendered_html h2:first-child,
+.reveal .rendered_html h3:first-child,
+.reveal .rendered_html h4:first-child,
+.reveal .rendered_html h5:first-child {
+    margin-top: 0.2em;
+}
+
+h1.plan, h2.plan, h3.plan {
+    text-align: center;
+    padding-bottom: 30px;
+}
+
+ul.plan>li>span.plan-bold {
+    font-size: 110%;
+    padding: 4px;
+    font-weight: bold;
+    background-color: #eee;
+}
+
+ul.plan>li>ul.subplan>li>span.plan-bold {
+    font-weight: bold;
+}
+
+.plan-strike {
+    opacity: 0.4;
+/*    text-decoration: line-through; */
+}
+
+div.plan-container {
+    display: grid;
+    grid-template-columns: 50% 50%;
+}
+
+/* something big and stupid again just to outline
+   that this file is actually loaded */
+
+div.cell.code_cell.rendered, div.input_area {
+    border-width: 10px;
 }

--- a/examples/showflow.ipynb
+++ b/examples/showflow.ipynb
@@ -371,7 +371,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.3"
   },
-  "livereveal": {
+  "rise": {
    "autolaunch": true,
    "slideNumber": "c/t"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "less": "~2.7.2",
     "less-plugin-autoprefix": "~1.4.2",
     "less-plugin-clean-css": "~1.5.0",
-    "reveal.js": "~3.7.0",
+    "reveal.js": "~3.5.0",
     "reveal.js-chalkboard": "~1.0.0",
     "notes_rise": "~1.0.0",
     "watch": "~0.16.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "less": "~2.7.2",
     "less-plugin-autoprefix": "~1.4.2",
     "less-plugin-clean-css": "~1.5.0",
-    "reveal.js": "~3.5.0",
+    "reveal.js": "~3.7.0",
     "reveal.js-chalkboard": "~1.0.0",
     "notes_rise": "~1.0.0",
     "watch": "~0.16.0"

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -70,8 +70,8 @@ define([
       shortcuts: {
         'slideshow' : 'alt-r',
         'toggle-slide': 'shift-i',
-        'toggle-subslide': 'shift-u',
-        'toggle-fragment': 'shift-f',
+        'toggle-subslide': 'shift-b',
+        'toggle-fragment': 'shift-g',
         // this can be helpful
         'rise-nbconfigurator': 'shift-c',
         // unassigned by default
@@ -950,7 +950,7 @@ define([
                      "toggle-fragment", "RISE");
 
     actions.register({ help   : '(un)set current cell as a Note cell',
-                       handler: function() { toggle_slide_type('note'); }
+                       handler: function() { toggle_slide_type('notes'); }
                      },
                      "toggle-notes", "RISE");
 

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -1014,6 +1014,11 @@ define([
 
   }
 
+  // could maybe become configurable
+  let restoreTimeout = 500;
+  // when going too short, like 250, I can see selection behaving oddly
+  let autoSelectTimeout = 500;
+
   // the entrypoint - call this to enter or exit reveal mode
   function revealMode() {
     // We search for a class tag in the maintoolbar to check if reveal mode is "on".
@@ -1046,11 +1051,10 @@ define([
       // select and focus on current cell
       Jupyter.notebook.select(current_cell_index);
       // Need to delay the action a little bit so it actually focus the selected slide
-      setTimeout(() => Jupyter.notebook.get_selected_cell().ensure_focused(), 500);
+      setTimeout(() => Jupyter.notebook.get_selected_cell().ensure_focused(),
+                 restoreTimeout);
     }
   }
-
-  let autoSelectTimeout = 250;
 
   function autoSelectHook() {
     let auto_select = complete_config.auto_select;

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -1069,7 +1069,8 @@ define([
       let current_cell_index = reveal_cell_index(
           Jupyter.notebook, cell_type, auto_select_fragment);
       // select and focus on current cell
-      Jupyter.notebook.select(current_cell_index)
+      if (current_cell_index)
+        Jupyter.notebook.select(current_cell_index);
     }, autoSelectTimeout);
   }
 

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -65,6 +65,11 @@ define([
       backimage: undefined,
       overlay: undefined,
 
+      // timeouts
+      restore_timeout: 500,
+      // when going too short, like 250, size of selected cell get odd
+      auto_select_timeout: 500,
+
       // UI
       toolbar_icon: 'fa-bar-chart',
       shortcuts: {
@@ -1018,10 +1023,6 @@ define([
 
   }
 
-  // could maybe become configurable
-  let restoreTimeout = 500;
-  // when going too short, like 250, I can see selection behaving oddly
-  let autoSelectTimeout = 500;
 
   // the entrypoint - call this to enter or exit reveal mode
   function revealMode() {
@@ -1056,7 +1057,7 @@ define([
       Jupyter.notebook.select(current_cell_index);
       // Need to delay the action a little bit so it actually focus the selected slide
       setTimeout(() => Jupyter.notebook.get_selected_cell().ensure_focused(),
-                 restoreTimeout);
+                 complete_config.restore_timeout);
     }
   }
 
@@ -1079,7 +1080,7 @@ define([
       // select and focus on current cell
       if (current_cell_index)
         Jupyter.notebook.select(current_cell_index);
-    }, autoSelectTimeout);
+    }, complete_config.auto_select_timeout);
   }
 
   function addButtonsAndShortcuts() {

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -1031,7 +1031,11 @@ define([
       buttonHelp();
       $('#maintoolbar').addClass('reveal_tagging');
     } else {
-      let current_cell_index = reveal_cell_index(Jupyter.notebook);
+      let current_cell_index =
+         // first use current selection if relevant
+        Jupyter.notebook.get_selected_index()
+        // resort to first cell in visible slide otherwise
+        || reveal_cell_index(Jupyter.notebook);
       Remover();
       setupKeys("notebook_mode");
       $('#exit_b').remove();

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -496,6 +496,10 @@ define([
 
     }
 
+    function toggleAllRiseButtons() {
+        $('#help_b,#exit_b,#toggle-chalkboard,#toggle-notes').fadeToggle()
+    }
+
     // Tailer
     require([
       './reveal.js/lib/js/head.min.js',
@@ -537,7 +541,7 @@ define([
                   80: null, // p, up disabled
                   // 84: RevealNotes.open, // t, modified in the custom notes plugin.
                   87: Reveal.toggleOverview, // w, toggle overview
-                  188: () => $('#help_b,#exit_b').fadeToggle(), // comma
+                  188: toggleAllRiseButtons, // comma
                 },
 
                 dependencies: [

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -584,7 +584,7 @@ define([
                 // could hopefully avoid conflicting behaviours in case of overlaps
                 $.extend(options.keyboard, {
                            // for chalkboard; also bind uppercases just in case
-                           63:  KeysMessager,                               // '?' show our help
+                           63:  riseHelp,                               // '?' show our help
                            // can't use just RevealChalkboard.reset directly here
                            // because RevealChalkboard is not yet loaded at that time
                            187: () => RevealChalkboard.reset(),             // '=' reset chalkboard data on current slide
@@ -697,27 +697,28 @@ define([
     }
   }
 
-  function KeysMessager() {
+  function riseHelp() {
     let message = $('<div/>').append(
       $("<p/></p>").addClass('dialog').html(
         "<ul>" +
-          "<li><kbd>Alt</kbd>+<kbd>r</kbd>: Enter/Exit RISE</li>" +
-          "<li><kbd>Space</kbd>: Next</li>" +
-          "<li><kbd>Shift</kbd>+<kbd>Space</kbd>: Previous</li>" +
-          "<li><kbd>Shift</kbd>+<kbd>Enter</kbd>: Eval and select next cell if visible</li>" +
-          "<li><kbd>Home</kbd>: First slide</li>" +
-          "<li><kbd>End</kbd>: Last slide</li>" +
-          "<li><kbd>w</kbd>: Toggle overview mode</li>" +
-          "<li><kbd>,</kbd>: Toggle help and exit buttons</li>" +
-          "<li><kbd>.</kbd> or <kbd>/</kbd>: black screen</li>" +
-          "<li><strong>Not so useful:</strong>" +
+          "<li><kbd>Alt</kbd>+<kbd>r</kbd>: enter/exit RISE</li>" +
+          "<li><kbd>Space</kbd>: next</li>" +
+          "<li><kbd>Shift</kbd>+<kbd>Space</kbd>: previous</li>" +
+          "<li><kbd>Shift</kbd>+<kbd>Enter</kbd>: eval and select next cell if visible</li>" +
+          "<li><kbd>Home</kbd>: first slide</li>" +
+          "<li><kbd>End</kbd>: last slide</li>" +
+          "<li><kbd>w</kbd>: toggle overview mode</li>" +
+          "<li><kbd>t</kbd>: toggle notes</li>" +
+          "<li><kbd>,</kbd>: toggle help and exit buttons</li>" +
+          "<li><kbd>/</kbd>: black screen</li>" +
+          "<li><strong>less useful:</strong>" +
             "<ul>" +
-            "<li><kbd>PgUp</kbd>: Up</li>" +
-            "<li><kbd>PgDn</kbd>: Down</li>" +
-            "<li><kbd>Left Arrow</kbd>: Left <em>(note: Space preferred)</em></li>" +
-            "<li><kbd>Right Arrow</kbd>: Right <em>(note: Shift Space preferred)</em></li>" +
+            "<li><kbd>PgUp</kbd>: up</li>" +
+            "<li><kbd>PgDn</kbd>: down</li>" +
+            "<li><kbd>Left Arrow</kbd>: left <em>(note: Space preferred)</em></li>" +
+            "<li><kbd>Right Arrow</kbd>: right <em>(note: Shift Space preferred)</em></li>" +
             "</ul>" +
-          "<li><strong>With chalkboard enabled:</strong>" +
+          "<li><strong>with chalkboard enabled:</strong>" +
             "<ul>" +
             "<li><kbd>[</kbd> toggle fullscreen chalkboard</li>" +
             "<li><kbd>]</kbd> toggle slide-local canvas</li>" +
@@ -726,7 +727,7 @@ define([
             "<li><kbd>-</kbd> delete fullscreen chalkboard</li>" +
             "</ul>" +
           "</ul>" +
-          "<b>NOTE: You have to use these shortcuts in command mode.</b>"
+          "<b>NOTE</b>: of course you have to use these shortcuts <b>in command mode.</b>"
       )
     );
 
@@ -745,7 +746,7 @@ define([
         .attr('title','Reveal Shortcuts Help')
         .addClass('fa-question fa-4x fa')
         .addClass('my-main-tool-bar')
-        .click(KeysMessager);
+        .click(riseHelp);
     $('.reveal').after(help_button);
   }
 

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -927,15 +927,15 @@ define([
     let actions = Jupyter.notebook.keyboard_manager.actions;
 
     // register main action
-    actions.register({ help    : 'Enter/Exit RISE Slideshow',
-                       handler : revealMode,
-                     },
-                     "slideshow", "RISE");
+    actions.register(
+        {help:    "Enter/Exit RISE Slideshow",
+         handler: revealMode},
+        "slideshow", "RISE");
 
-    actions.register({ help: "execute cell, and move to the next if on the same slide",
-                       handler: smartExec,
-                     },
-                     "smart-exec", "RISE");
+    actions.register(
+        {help:    "execute cell, and move to the next if on the same slide",
+         handler: smartExec},
+        "smart-exec", "RISE");
 
     // helpers for toggling slide_type
     function init_metadata_slideshow(optional_cell) {
@@ -954,49 +954,43 @@ define([
       Jupyter.CellToolbar.rebuild_all();
     }
 
-    actions.register({ help   : '(un)set current cell as a Slide cell',
-                       handler: function() { toggle_slide_type('slide'); }
-                     },
-                     "toggle-slide", "RISE");
+    actions.register(
+        {help   : '(un)set current cell as a Slide cell',
+         handler: () => toggle_slide_type('slide')},
+        "toggle-slide", "RISE");
 
-    actions.register({ help   : '(un)set current cell as a Sub-slide cell',
-                       handler: function() { toggle_slide_type('subslide'); }
-                     },
-                     "toggle-subslide", "RISE");
+    actions.register(
+        {help   : '(un)set current cell as a Sub-slide cell',
+         handler: () => toggle_slide_type('subslide')},
+        "toggle-subslide", "RISE");
 
-    actions.register({ help   : '(un)set current cell as a Fragment cell',
-                       handler: function() { toggle_slide_type('fragment'); }
-                     },
-                     "toggle-fragment", "RISE");
+    actions.register(
+        {help   : '(un)set current cell as a Fragment cell',
+         handler: () => toggle_slide_type('fragment')},
+        "toggle-fragment", "RISE");
 
-    actions.register({ help   : '(un)set current cell as a Note cell',
-                       handler: function() { toggle_slide_type('notes'); }
-                     },
-                     "toggle-notes", "RISE");
+    actions.register(
+        {help   : '(un)set current cell as a Note cell',
+         handler: () => toggle_slide_type('notes')},
+        "toggle-notes", "RISE");
 
-    actions.register({ help   : '(un)set current cell as a Skip cell',
-                       handler: function() { toggle_slide_type('skip'); }
-                     },
-                     "toggle-skip", "RISE");
+    actions.register(
+        {help   : '(un)set current cell as a Skip cell',
+         handler: () => toggle_slide_type('skip')},
+        "toggle-skip", "RISE");
 
 
-    actions.register({ help   : 'render all cells (all cells go to command mode)',
-                       handler: function() {
-                         Jupyter.notebook.get_cells().forEach(function(cell){
-	                   cell.render();
-                         })
-                       }
-                     },
-                     "render-all-cells", "RISE");
+    actions.register(
+        {help   : 'render all cells (all cells go to command mode)',
+         handler: function() {
+             Jupyter.notebook.get_cells().forEach(cell => cell.render())}},
+        "render-all-cells", "RISE");
 
-    actions.register({ help   : 'edit all cells (all cells go to edit mode)',
-                       handler: function() {
-                         Jupyter.notebook.get_cells().forEach(function(cell){
-	                   cell.unrender();
-                         })
-                       }
-                     },
-                     "edit-all-cells", "RISE");
+    actions.register(
+        {help   : 'edit all cells (all cells go to edit mode)',
+        handler: function() {
+            Jupyter.notebook.get_cells().forEach(cell => cell.unrender())}},
+        "edit-all-cells", "RISE");
 
     // because the `Edit Keyboard Shortcuts` utility does not mention the
     // actions prefix (i.e. 'RISE' in our case), we choose to make these two
@@ -1008,14 +1002,16 @@ define([
       window.open(url, '_blank');
     }
 
-    actions.register({ help: 'open the nbconfigurator page for RISE',
-                       handler: nbconfigurator},
-                     "rise-nbconfigurator", "RISE");
+    actions.register(
+        {help: 'open the nbconfigurator page for RISE',
+         handler: nbconfigurator},
+        "rise-nbconfigurator", "RISE");
 
     // mostly for debug / information
-    actions.register({ help   : 'output RISE configuration in console, for debugging mostly',
-                       handler: showConfig},
-                     "rise-dump-config", "RISE");
+    actions.register(
+        {help   : 'output RISE configuration in console, for debugging mostly',
+         handler: showConfig},
+        "rise-dump-config", "RISE");
 
   }
 

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -477,11 +477,20 @@ define([
      * should be redefinable in the config
      */
     if (window.location.pathname.endsWith('.ipynb')) {
+      // typically examples/README.ipynb
+      let path = Jupyter.notebook.notebook_path;
+      // typically README.ipynb
+      let name = Jupyter.notebook.notebook_name;
+      // asscosiated css
+      let name_css = name.replace(".ipynb", ".css");
+      // typically /files/examples/
+      let prefix = `/files/${path.replace(name, '')}`;
       // Attempt to load rise.css
-      $('head').append(`<link rel="stylesheet" href="./rise.css" id="rise-custom-css" />`);
-      // Attempt to load CSS with the same path as the .ipynb but with .css extension instead
-      let notebook_css = window.location.pathname.replace(/\.ipynb$/,'.css');
-      $('head').append(`<link rel="stylesheet" href="${notebook_css}" id="notebook-custom-css" />`);
+      $('head').append(
+          `<link rel="stylesheet" href="${prefix}rise.css" id="rise-custom-css" />`);
+      // Attempt to load css with the same path as notebook
+      $('head').append(
+          `<link rel="stylesheet" href="${prefix}${name_css}" id="notebook-custom-css" />`);
 
     }
 

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -1085,7 +1085,7 @@ define([
   function setup() {
     // load css first
     $('<link/>')
-      .attr({rel: " stylesheet",
+      .attr({rel: "stylesheet",
              href: require.toUrl("./main.css"),
              id: 'maincss',
             })

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -44,14 +44,14 @@ define([
    * waiting for any asyncronous code to complete
    */
 
-  var complete_config = {};
+  let complete_config = {};
 
   // returns a promise; you can do 'then()' on this promise
   // to do stuff *after* the configuration is completely loaded
   function configLoaded() {
 
     // see rise.yaml for more details
-    var hardwired_config = {
+    let hardwired_config = {
 
       // behaviour
       autolaunch: false,
@@ -179,7 +179,7 @@ define([
    * also sometimes slide_type is set to '-' by the toolbar
    */
   function get_slide_type(cell) {
-    var slide_type = (cell.metadata.slideshow || {}).slide_type;
+    let slide_type = (cell.metadata.slideshow || {}).slide_type;
     return ( (slide_type === undefined) || (slide_type == '-')) ? '' : slide_type;
   }
 
@@ -205,8 +205,8 @@ define([
    */
   function markupSlides(container) {
     // Machinery to create slide/subslide <section>s and give them IDs
-    var slide_counter = -1, subslide_counter = -1;
-    var slide_section, subslide_section;
+    let slide_counter = -1, subslide_counter = -1;
+    let slide_section, subslide_section;
     function new_slide() {
       slide_counter++;
       subslide_counter = -1;
@@ -221,10 +221,10 @@ define([
     // Containers for the first slide.
     slide_section = new_slide();
     subslide_section = new_subslide();
-    var current_fragment = subslide_section;
+    let current_fragment = subslide_section;
 
-    var selected_cell_idx = Jupyter.notebook.get_selected_index();
-    var selected_cell_slide = [0, 0];
+    let selected_cell_idx = Jupyter.notebook.get_selected_index();
+    let selected_cell_slide = [0, 0];
 
     /* Special handling for the first slide: it will work even if the user
      * doesn't start with a 'Slide' cell. But if the user does explicitly
@@ -232,13 +232,13 @@ define([
      * don't create a new slide/subslide until there is visible content on
      * the first slide.
      */
-    var content_on_slide1 = false;
+    let content_on_slide1 = false;
 
-    var cells = Jupyter.notebook.get_cells();
+    let cells = Jupyter.notebook.get_cells();
 
-    for (var i=0; i < cells.length; i++) {
-      var cell = cells[i];
-      var slide_type = get_slide_type(cell);
+    for (let i=0; i < cells.length; i++) {
+      let cell = cells[i];
+      let slide_type = get_slide_type(cell);
 
       if (content_on_slide1) {
         if (slide_type === 'slide') {
@@ -292,13 +292,13 @@ define([
      * corresponding to the (usually immediately) next cell
      * that is a fragment cell
      */
-    for (var i=0; i < cells.length; i++) {
-      var cell = cells[i];
+    for (let i=0; i < cells.length; i++) {
+      let cell = cells[i];
       // default is 'pinned' because this applies to the last cell
-      var tag = 'smart_exec_slide';
-      for (var j = i+1; j < cells.length; j++) {
-        var next_cell = cells[j];
-        var next_type = get_slide_type(next_cell);
+      let tag = 'smart_exec_slide';
+      for (let j = i+1; j < cells.length; j++) {
+        let next_cell = cells[j];
+        let next_type = get_slide_type(next_cell);
         if ((next_type == 'slide') || (next_type) == 'subslide') {
           tag = 'smart_exec_slide';
           break;
@@ -331,7 +331,7 @@ define([
    */
   function setStartingSlide(selected) {
 
-    var start_slideshow = complete_config.start_slideshow_at;
+    let start_slideshow = complete_config.start_slideshow_at;
     if (start_slideshow === 'selected') {
       // Start from the selected cell
       Reveal.slide(selected[0], selected[1]);
@@ -347,9 +347,9 @@ define([
    */
   function setScrollingSlide() {
 
-    var scroll = complete_config.scroll;
+    let scroll = complete_config.scroll;
     if (scroll === true) {
-      var h = $('.reveal').height() * 0.95;
+      let h = $('.reveal').height() * 0.95;
       $('section.present').find('section')
         .filter(function() {
           return $(this).height() > h;
@@ -375,10 +375,10 @@ define([
     }
 
     // Ref: https://stackoverflow.com/a/7739035
-    var url = (window.location != window.parent.location)
+    let url = (window.location != window.parent.location)
             ? document.referrer
             : document.location.href;
-    var lastPart = url.substr(url.lastIndexOf('/') + 1);
+    let lastPart = url.substr(url.lastIndexOf('/') + 1);
 
     if (lastPart === "notes.html") {
       revealMode();
@@ -388,7 +388,7 @@ define([
   /* Setup a MutationObserver to call Reveal.sync when an output is generated.
    * This fixes issue #188: https://github.com/damianavila/RISE/issues/188
    */
-  var outputObserver = null;
+  let outputObserver = null;
   function setupOutputObserver() {
     function mutationHandler(mutationRecords) {
       mutationRecords.forEach(function(mutation) {
@@ -399,11 +399,11 @@ define([
       });
     }
 
-    var $output = $(".output");
-    var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+    let $output = $(".output");
+    let MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
     outputObserver = new MutationObserver(mutationHandler);
 
-    var observerOptions = { childList: true,
+    let observerOptions = { childList: true,
                            characterData: false,
                            attributes: false,
                            subtree: false
@@ -464,7 +464,7 @@ define([
 
     // Header
     // Available themes are in static/css/theme
-    var theme = complete_config.theme;
+    let theme = complete_config.theme;
     $('head')
       .prepend('<link rel="stylesheet" href='
                + require.toUrl("./reveal.js/css/theme/" + theme + ".css")
@@ -513,7 +513,7 @@ define([
               let inherited = ['controls', 'progress', 'history', 'width', 'height', 'margin',
                                'minScale', 'transition', 'slideNumber', 'center', 'help'];
 
-              var options = {
+              let options = {
 
                 //parallaxBackgroundImage: 'https://raw.github.com/damianavila/par_IPy_slides_example/gh-pages/figs/star_wars_stormtroopers_darth_vader.jpg',
                 //parallaxBackgroundSize: '2560px 1600px',
@@ -537,7 +537,7 @@ define([
                   80: null, // p, up disabled
                   // 84: RevealNotes.open, // t, modified in the custom notes plugin.
                   87: Reveal.toggleOverview, // w, toggle overview
-                  188: function() {$('#help_b,#exit_b').fadeToggle();},
+                  188: () => $('#help_b,#exit_b').fadeToggle(), // comma
                 },
 
                 dependencies: [
@@ -560,7 +560,7 @@ define([
               }
 
               ////////// set up the leap motion integration if configured
-              var enable_leap_motion = complete_config.enable_leap_motion;
+              let enable_leap_motion = complete_config.enable_leap_motion;
               if (enable_leap_motion) {
                 options.dependencies.push({ src: require.toUrl('./reveal.js/plugin/leap/leap.js'), async: true });
                 options.leap = enable_leap_motion;
@@ -573,15 +573,16 @@ define([
                 // xxx need to explore the option of registering jupyter actions
                 // and have jupyter handle the keyboard entirely instead of this approach
                 // could hopefully avoid conflicting behaviours in case of overlaps
-                $.extend(options.keyboard,
-                         {
+                $.extend(options.keyboard, {
                            // for chalkboard; also bind uppercases just in case
-                           63:  KeysMessager,                                        // '?' show our help
-                           187:  function() { RevealChalkboard.reset() },             // '=' reset chalkboard data on current slide
-                           189:  function() { RevealChalkboard.clear() },             // '-' clear full size chalkboard
-                           219:  function() { RevealChalkboard.toggleChalkboard() },  // '[' toggle full size chalkboard
-                           221:  function() { RevealChalkboard.toggleNotesCanvas() }, // ']' toggle notes (slide-local)
-                           220:  function() { RevealChalkboard.download() },          // '\' download recorded chalkboard drawing
+                           63:  KeysMessager,                               // '?' show our help
+                           // can't use just RevealChalkboard.reset directly here
+                           // because RevealChalkboard is not yet loaded at that time
+                           187: () => RevealChalkboard.reset(),             // '=' reset chalkboard data on current slide
+                           189: () => RevealChalkboard.clear(),             // '-' clear full size chalkboard
+                           219: () => RevealChalkboard.toggleChalkboard(),  // '[' toggle full size chalkboard
+                           221: () => RevealChalkboard.toggleNotesCanvas(), // ']' toggle notes (slide-local)
+                           220: () => RevealChalkboard.download(),          // '\' download recorded chalkboard drawing
                          });
               }
 
@@ -595,24 +596,24 @@ define([
                 //console.log("Reveal initialized");
               }
 
-              Reveal.addEventListener( 'ready', function( event ) {
+              Reveal.addEventListener('ready', function(event) {
                 Unselecter();
                 // check and set the scrolling slide when you start the whole thing
                 setScrollingSlide();
                 autoSelectHook();
               });
 
-              Reveal.addEventListener( 'slidechanged', function( event ) {
+              Reveal.addEventListener('slidechanged', function(event) {
                 Unselecter();
                 // check and set the scrolling slide every time the slide change
                 setScrollingSlide();
                 autoSelectHook();
               });
 
-              Reveal.addEventListener( 'fragmentshown', function( event ) {
+              Reveal.addEventListener('fragmentshown', function(event) {
                 autoSelectHook();
               });
-              Reveal.addEventListener( 'fragmenthidden', function( event ) {
+              Reveal.addEventListener('fragmenthidden', function(event) {
                 autoSelectHook();
               });
 
@@ -627,23 +628,21 @@ define([
   }
 
   function Unselecter(){
-    var cells = Jupyter.notebook.get_cells();
-    for(var i in cells){
-      var cell = cells[i];
+    let cells = Jupyter.notebook.get_cells();
+    for (let cell of cells){
       cell.unselect();
     }
   }
 
   function fixCellHeight(){
     // Let's start with all the cell unselected, the unselect the current selected one
-    var scell = Jupyter.notebook.get_selected_cell()
-    scell.unselect()
+    let scell = Jupyter.notebook.get_selected_cell();
+    scell.unselect();
     // This select/unselect code cell triggers the "correct" heigth in the codemirror instance
-    var cells = Jupyter.notebook.get_cells();
-    for(var i in cells){
-      var cell = cells[i];
+    let cells = Jupyter.notebook.get_cells();
+    for (let cell of cells){
       if (cell.cell_type === "code") {
-        cell.select()
+        cell.select();
         cell.unselect();
       }
     }
@@ -655,14 +654,14 @@ define([
    */
   function smartExec() {
     // is it really the selected cell that matters ?
-    var smart_exec = Jupyter.notebook.get_selected_cell().smart_exec;
+    let smart_exec = Jupyter.notebook.get_selected_cell().smart_exec;
     if (smart_exec == 'smart_exec_slide') {
       Jupyter.notebook.execute_selected_cells();
     } else if (smart_exec == "smart_exec_fragment") {
       // let's see if the next fragment is visible or not
-      var cell = Jupyter.notebook.get_selected_cell();
-      var fragment_div = cell.smart_exec_next_fragment;
-      var visible = $(fragment_div).hasClass('visible');
+      let cell = Jupyter.notebook.get_selected_cell();
+      let fragment_div = cell.smart_exec_next_fragment;
+      let visible = $(fragment_div).hasClass('visible');
       if (visible) {
         Jupyter.notebook.execute_cell_and_select_below();
       } else {
@@ -690,7 +689,7 @@ define([
   }
 
   function KeysMessager() {
-    var message = $('<div/>').append(
+    let message = $('<div/>').append(
       $("<p/></p>").addClass('dialog').html(
         "<ul>" +
           "<li><kbd>Alt</kbd>+<kbd>r</kbd>: Enter/Exit RISE</li>" +
@@ -732,7 +731,7 @@ define([
   }
 
   function buttonHelp() {
-    var help_button = $('<i/>')
+    let help_button = $('<i/>')
         .attr('id','help_b')
         .attr('title','Reveal Shortcuts Help')
         .addClass('fa-question fa-4x fa')
@@ -742,7 +741,7 @@ define([
   }
 
   function buttonExit() {
-    var exit_button = $('<i/>')
+    let exit_button = $('<i/>')
         .attr('id','exit_b')
         .attr('title','Exit RISE')
         .addClass('fa-times-circle fa-4x fa')
@@ -752,7 +751,7 @@ define([
   }
 
   function fullscreenHelp() {
-    var message = $('<div/>').append(
+    let message = $('<div/>').append(
       $("<p/></p>").addClass('dialog').html(
         "<b>Entering Fullscreen mode from inside RISE is disabled.</b>" +
           "<br>" +
@@ -803,8 +802,8 @@ define([
     $('.pause-overlay').hide();
     $('div#aria-status-div').hide();
 
-    var cells = Jupyter.notebook.get_cells();
-    for(var i in cells){
+    let cells = Jupyter.notebook.get_cells();
+    for(let i in cells){
       $('.cell:nth('+i+')').removeClass('reveal-skip');
       $('div#notebook-container').append(cells[i].element);
     }
@@ -940,7 +939,7 @@ define([
     // helpers for toggling slide_type
     function init_metadata_slideshow(optional_cell) {
       // use selected cell if not specified
-      var cell = optional_cell || Jupyter.notebook.get_selected_cell();
+      let cell = optional_cell || Jupyter.notebook.get_selected_cell();
       let metadata = cell.metadata;
       if (metadata.slideshow === undefined)
         metadata.slideshow = {};
@@ -982,14 +981,14 @@ define([
 
     actions.register(
         {help   : 'render all cells (all cells go to command mode)',
-         handler: function() {
-             Jupyter.notebook.get_cells().forEach(cell => cell.render())}},
+         handler: () => Jupyter.notebook.get_cells().forEach(
+             cell => cell.render())},
         "render-all-cells", "RISE");
 
     actions.register(
         {help   : 'edit all cells (all cells go to edit mode)',
-        handler: function() {
-            Jupyter.notebook.get_cells().forEach(cell => cell.unrender())}},
+         handler: () => Jupyter.notebook.get_cells().forEach(
+            cell => cell.unrender())},
         "edit-all-cells", "RISE");
 
     // because the `Edit Keyboard Shortcuts` utility does not mention the
@@ -1019,11 +1018,11 @@ define([
   function revealMode() {
     // We search for a class tag in the maintoolbar to check if reveal mode is "on".
     // If the tag exits, we exit. Otherwise, we enter the reveal mode.
-    var tag = $('#maintoolbar').hasClass('reveal_tagging');
+    let tag = $('#maintoolbar').hasClass('reveal_tagging');
 
     if (!tag) {
       // Preparing the new reveal-compatible structure
-      var selected_slide = markupSlides($('div#notebook-container'));
+      let selected_slide = markupSlides($('div#notebook-container'));
       // Adding the reveal stuff
       Revealer(selected_slide);
       // Minor modifications for usability
@@ -1032,7 +1031,7 @@ define([
       buttonHelp();
       $('#maintoolbar').addClass('reveal_tagging');
     } else {
-      var current_cell_index = reveal_cell_index(Jupyter.notebook);
+      let current_cell_index = reveal_cell_index(Jupyter.notebook);
       Remover();
       setupKeys("notebook_mode");
       $('#exit_b').remove();
@@ -1043,15 +1042,15 @@ define([
       // select and focus on current cell
       Jupyter.notebook.select(current_cell_index);
       // Need to delay the action a little bit so it actually focus the selected slide
-      setTimeout(function(){ Jupyter.notebook.get_selected_cell().ensure_focused(); }, 500);
+      setTimeout(() => Jupyter.notebook.get_selected_cell().ensure_focused(), 500);
     }
   }
 
   let autoSelectTimeout = 250;
 
   function autoSelectHook() {
-    var auto_select = complete_config.auto_select;
-    var cell_type =
+    let auto_select = complete_config.auto_select;
+    let cell_type =
         (auto_select == "code") ? 'code'
 	: (auto_select == "first") ? null
 	: undefined;
@@ -1061,9 +1060,10 @@ define([
       return;
     }
 
-    var auto_select_fragment = complete_config.auto_select_fragment;
+    let auto_select_fragment = complete_config.auto_select_fragment;
     setTimeout(function(){
-      var current_cell_index = reveal_cell_index(Jupyter.notebook, cell_type, auto_select_fragment);
+      let current_cell_index = reveal_cell_index(
+          Jupyter.notebook, cell_type, auto_select_fragment);
       // select and focus on current cell
       Jupyter.notebook.select(current_cell_index)
     }, autoSelectTimeout);

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -124,11 +124,11 @@ Parameters:
 - name: rise.shortcuts.toggle-subslide
   description: <code>rise.shortcuts.toggle-subslide</code> shortcut to toggle the 'subslide' tag on current cell
   input_type: hotkey
-  default: shift-u
+  default: shift-b
 - name: rise.shortcuts.toggle-fragment
   description: <code>rise.shortcuts.toggle-fragment</code> shortcut to toggle the 'fragment' tag on current cell
   input_type: hotkey
-  default: shift-f
+  default: shift-g
 - name: rise.shortcuts.toggle-notes
   description: <code>rise.shortcuts.toggle-notes</code> shortcut to toggle the 'notes' tag on current cell
   input_type: hotkey

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -153,6 +153,23 @@ Parameters:
   default: shift-c
 
 #
+# mostly intended for developers
+#
+- name: rise.auto_select_timeout
+  description: >
+    timeout in milliseconds before auto-selecting; mostly
+    intended for developers.
+  input_type: number
+  default: 500
+
+- name: rise.restore_timeout
+  description: >
+    timeout in milliseconds before restoring focus to selected cell
+    when quitting slideshow mode; mostly intended for developers.
+  input_type: number
+  default: 500
+
+#
 # passed to reveal as-is
 #
 - name: rise.theme

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -186,7 +186,7 @@ Parameters:
 #
 - name: rise.transition
   description: >
-    <code>transition</code>: at least available: none - fade - slide - convex - concave - zoom - cube - linear
+    <code>transition</code>: at least available: none - fade - slide - convex - concave - zoom - cube - linear; see also <code>reveal.js</code>.
   input_type: string
   default: 'linear'
 #

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -7,8 +7,13 @@
   transition-timing-function: ease;
 }
 
-.rise-enabled {
+/* do not apply this on the <body> tag */
+:not(body).rise-enabled {
   background-color: #fff;
+}
+
+
+.rise-enabled {
   .transition-all;
 
   /* Reveal-specific */


### PR DESCRIPTION
review - hopefully - all places that relate to keyboard shortcut definitions

new scheme is to use - with Shift modifier:

* I for slIde
* B for suBslide
* G for fraGment

* C for Configurator - this still requires setting up nbextensions configurator

finally, there was a typo where 'note' was mentioned instead of 'notes', which
should make toggle-notes now work as expected