### PR TITLE
Fix scrollbar below cells with inline code

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -80,9 +80,9 @@
     }
     
     /* This fixes an issue where the scrollbar would appear below cells containing inline code. */
-	  .text_cell_render {
-	   padding-right: 5%;
-	  }
+    .text_cell_render {
+      padding-right: 5%;
+    }
     
     .reveal-skip, .reveal-notes { display: none; }
 

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -78,7 +78,12 @@
       margin-bottom: 0;
       span { background: @some-grey; }
     }
-
+    
+    /* This fixes an issue where the scrollbar would appear below cells containing inline code. */
+	  .text_cell_render {
+	   padding-right: 5%;
+	  }
+    
     .reveal-skip, .reveal-notes { display: none; }
 
   } // .reveal


### PR DESCRIPTION
This fixes #430 an issue where horizontal scrollbars would appear below cells containing inline code by adding a small padding to every .text_cell_render.