### PR TITLE
fix for #456

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -161,6 +161,18 @@
 					font-size: 1.2em;
 				}
 
+				/* for issue #456, remove spurrious, i.e. duplicate or useless
+				 * contents in this area
+				 * first is the drop down with Slide Type, that I guess comes
+				 * from a representation of the 'notes' cell with the cell toolbar being set to Slide,
+				 * second is the duplicate cell notes contents, in fixed font
+				 */
+				#speaker-controls>.speaker-controls-notes .inner_cell>.ctb_hideshow,
+				#speaker-controls>.speaker-controls-notes .inner_cell>.input_area {
+					display: none;
+				}
+
+
 			/* Layout selector */
 			#speaker-layout {
 				position: absolute;


### PR DESCRIPTION
remove duplicate notes, and useless drop down, in the notes view

again I've had terrible experience when testing this; for the record, when trying to guess which file was being served by my virtualenv'ed jupyter, I've seen this:

```
find venv /Users/tparment/Library/Jupyter/nbextensions/rise  -name notes.html | xargs ls -l
-rw-r--r--  1 tparment  staff  19097 Apr 19 12:34 /Users/tparment/Library/Jupyter/nbextensions/rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  19097 Apr 19 12:34 /Users/tparment/Library/Jupyter/nbextensions/rise/notes_rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  13582 Apr 19 11:44 /Users/tparment/Library/Jupyter/nbextensions/rise/reveal.js/plugin/notes-server/notes.html
-rw-r--r--  1 tparment  staff  18597 Apr 19 11:44 /Users/tparment/Library/Jupyter/nbextensions/rise/reveal.js/plugin/notes/notes.html
-rw-r--r--  1 tparment  staff  13582 Mar 25 16:41 /Users/tparment/Library/Jupyter/nbextensions/rise/reveal.js/reveal.js/plugin/notes-server/notes.html
-rw-r--r--  1 tparment  staff  18597 Mar 25 16:41 /Users/tparment/Library/Jupyter/nbextensions/rise/reveal.js/reveal.js/plugin/notes/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/notes_rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  13582 Mar 25 14:58 venv/jupyter/nbextensions/nbextensions/rise/reveal.js/plugin/notes-server/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/reveal.js/plugin/notes/notes.html
-rw-r--r--  1 tparment  staff  13582 Mar 25 14:43 venv/jupyter/nbextensions/nbextensions/rise/reveal.js/reveal.js/plugin/notes-server/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/reveal.js/reveal.js/plugin/notes/notes.html
```

and even when trying to be smart 
```
find venv /Users/tparment/Library/Jupyter/nbextensions/rise  -name notes.html | grep notes_rise | xargs ls -l
-rw-r--r--  1 tparment  staff  19097 Apr 19 12:34 /Users/tparment/Library/Jupyter/nbextensions/rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  19097 Apr 19 12:34 /Users/tparment/Library/Jupyter/nbextensions/rise/notes_rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/notes_rise/notes.html
-rw-r--r--  1 tparment  staff  19095 Apr 19 11:45 venv/jupyter/nbextensions/nbextensions/rise/notes_rise/notes_rise/notes.html
```

meaning the same file is present twice in each of both environments (local virtualenv for testing; global jupyter depl)

and btw I have found out during this work that:
* the way I currently 'push' my files so they can be tested, I write in the global context,
* but then when I run my local notebooks I use the files from the virtualenv..

this is totally unrelated to the PR at hand, but may shed some light on my troubles; next time I have a change I'll try to leverage this newly acquired knowledge and fix my workflow..