### PR TITLE
attempt at fixing #462

### DIFF
--- a/examples/rise.css
+++ b/examples/rise.css
@@ -55,3 +55,9 @@ div.plan-container {
 div.cell.code_cell.rendered, div.input_area {
     border-width: 10px;
 }
+
+/* this is only to check that rise.css properly gets
+ * ignored when quitting reveal mode */
+div.text_cell_render.rendered_html {
+    color: #5050b0;
+}

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -492,21 +492,13 @@ define([
       let name_css = name.replace(".ipynb", ".css");
       // typically /files/examples/
       let prefix = `/files/${path.replace(name, '')}`;
-      // rise.css stylesheet: either insert a <link> object,
-      // or enable it if present
-      if ($('#rise-custom-css').length == 0) {
-        $('head').append(
+      // Attempt to load rise.css
+      $('head').append(
           `<link rel="stylesheet" href="${prefix}rise.css" id="rise-custom-css" />`);
-      } else {
-        $('#rise-custom-css').prop('disabled', false);
-      }
-      // same with the stylesheet named after the notebook
-      if ($('#rise-notebook-css').length == 0) {
-        $('head').append(
+      // Attempt to load css with the same path as notebook
+      $('head').append(
           `<link rel="stylesheet" href="${prefix}${name_css}" id="rise-notebook-css" />`);
-        } else {
-          $('#rise-notebook-css').prop('disabled', false);
-        }
+
     }
 
     function toggleAllRiseButtons() {
@@ -811,8 +803,8 @@ define([
 
     $('#theme').remove();
     $('#revealcss').remove();
-    $('#rise-custom-css').prop('disabled', true);
-    $('#rise-notebook-css').prop('disabled', true);
+    $('#rise-custom-css').remove();
+    $('#rise-notebook-css').remove();
 
     $('.backgrounds').hide();
     $('.progress').hide();

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -497,7 +497,7 @@ define([
           `<link rel="stylesheet" href="${prefix}rise.css" id="rise-custom-css" />`);
       // Attempt to load css with the same path as notebook
       $('head').append(
-          `<link rel="stylesheet" href="${prefix}${name_css}" id="notebook-custom-css" />`);
+          `<link rel="stylesheet" href="${prefix}${name_css}" id="rise-notebook-css" />`);
 
     }
 
@@ -803,6 +803,8 @@ define([
 
     $('#theme').remove();
     $('#revealcss').remove();
+    $('#rise-custom-css').remove();
+    $('#rise-notebook-css').remove();
 
     $('.backgrounds').hide();
     $('.progress').hide();

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -492,13 +492,21 @@ define([
       let name_css = name.replace(".ipynb", ".css");
       // typically /files/examples/
       let prefix = `/files/${path.replace(name, '')}`;
-      // Attempt to load rise.css
-      $('head').append(
+      // rise.css stylesheet: either insert a <link> object,
+      // or enable it if present
+      if ($('#rise-custom-css').length == 0) {
+        $('head').append(
           `<link rel="stylesheet" href="${prefix}rise.css" id="rise-custom-css" />`);
-      // Attempt to load css with the same path as notebook
-      $('head').append(
+      } else {
+        $('#rise-custom-css').prop('disabled', false);
+      }
+      // same with the stylesheet named after the notebook
+      if ($('#rise-notebook-css').length == 0) {
+        $('head').append(
           `<link rel="stylesheet" href="${prefix}${name_css}" id="rise-notebook-css" />`);
-
+        } else {
+          $('#rise-notebook-css').prop('disabled', false);
+        }
     }
 
     function toggleAllRiseButtons() {
@@ -803,8 +811,8 @@ define([
 
     $('#theme').remove();
     $('#revealcss').remove();
-    $('#rise-custom-css').remove();
-    $('#rise-notebook-css').remove();
+    $('#rise-custom-css').prop('disabled', true);
+    $('#rise-notebook-css').prop('disabled', true);
 
     $('.backgrounds').hide();
     $('.progress').hide();


### PR DESCRIPTION
use jquery remove() to remove these 2 <link> elements, at the same time as the reveal material is removed as well
and  in the mix, adopting a more sensible naming scheme for these 2 <link> elements

this is entirely untested
