### PR TITLE
Reveal 3.8.0

### DIFF
--- a/examples/rise.css
+++ b/examples/rise.css
@@ -1,9 +1,9 @@
 /* this goes with my global default setting
  * that has rise use reveal's theme sky
  */
-.reveal {
+/*.reveal {
     font-family: "Quicksand", sans-serif;
-}
+}*/
 
 .reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6 {
     text-transform: initial;   /* sky.css says uppercase */

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "less": "PATH=./node_modules/.bin:$PATH lessc --autoprefix src/less/main.less rise/static/main.css",
     "watch-less": "./node_modules/.bin/watch 'npm run less' src/less"
   },
-  "version": "5.5.0"
+  "version": "5.6.0-dev0"
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "url": "https://github.com/damianavila/RISE.git"
   },
   "scripts": {
-    "build": "for target in build-css build-reveal reset-reveal; do npm run $target; done",
+    "build": "for target in build-css patch-themes build-reveal reset-reveal; do npm run $target; done",
     "build-css": "npm run less",
+    "patch-themes": "sed -i.patch 's|^body {|body.notebook_app.rise-enabled {|' node_modules/reveal.js/css/theme/*.css",
     "build-reveal": "for dep in reveal.js reveal.js-chalkboard notes_rise; do cp -r ./node_modules/$dep/ rise/static/$dep/; done",
     "reset-reveal": "sed -i.upstream '11 s_^_/*_' rise/static/reveal.js/css/reveal.css",
     "clean-reveal": "for dep in reveal.js reveal.js-chalkboard notes_rise; do rm -rf rise/static/$dep; done",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "for target in build-css patch-themes build-reveal reset-reveal; do npm run $target; done",
     "build-css": "npm run less",
-    "patch-themes": "sed -i.patch 's|^body {|body.notebook_app.rise-enabled {|' node_modules/reveal.js/css/theme/*.css",
+    "patch-themes": "bash patch-reveal/patch-reveal-themes.sh",
     "build-reveal": "for dep in reveal.js reveal.js-chalkboard notes_rise; do cp -r ./node_modules/$dep/ rise/static/$dep/; done",
     "reset-reveal": "sed -i.upstream '11 s_^_/*_' rise/static/reveal.js/css/reveal.css",
     "clean-reveal": "for dep in reveal.js reveal.js-chalkboard notes_rise; do rm -rf rise/static/$dep; done",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "less": "~2.7.2",
     "less-plugin-autoprefix": "~1.4.2",
     "less-plugin-clean-css": "~1.5.0",
-    "reveal.js": "~3.5.0",
+    "reveal.js": "~3.8.0",
     "reveal.js-chalkboard": "~1.0.0",
     "notes_rise": "~1.0.1",
     "watch": "~0.16.0"

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "less": "PATH=./node_modules/.bin:$PATH lessc --autoprefix src/less/main.less rise/static/main.css",
     "watch-less": "./node_modules/.bin/watch 'npm run less' src/less"
   },
-  "version": "5.6.0-dev0"
+  "version": "5.6.0-dev1"
 }

--- a/patch-reveal/patch-reveal-themes.sh
+++ b/patch-reveal/patch-reveal-themes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# trigger this from toplevel directory with
+# 
+# npm run patch-themes
+
+# 
+# when going to reveal-3.8.0 we found out that reveal's native themes 
+# like simple, sky, and similar, failed to have their global background 
+# show up in our slides
+# 
+# this script patches the original themes as shipping with reveal.js to
+# fix this issue
+# 
+# (*) one thing that goes wrong is when reveal tries to tweak settings 
+#     on just the 'body' tag; these don't make it to <body> because they 
+#     are too general and get superseded by other css in the jupyter arena
+#     so we replace these 'body {' definitions so they apply on
+#     a more specific css selector
+#
+# (*) that is still not enough, it took a while to find out, but 
+#     the body tag also needs background-attachment to be reset to fixed,
+#     somehow something defines it to 'scroll' which breaks it for those themes
+# 
+
+[ -d node_modules ] || {
+    echo "$0: need to npm install first"
+}
+
+for theme in node_modules/reveal.js/css/theme/*.css; do
+    # do those changes only once
+    # there's no mention of rise-enabled in the stock reveal.js
+    grep -q 'rise-enabled' $theme && { echo $theme already patched; continue; }
+    echo patching theme $theme for RISE
+    sed -i.patched \
+        -e "/^body/ a\\
+    /* PATCHED by $0 */\\
+    background-attachment: fixed !important;" \
+        -e "s|^body {|body.notebook_app.rise-enabled {|" \
+        $theme  
+done

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -507,7 +507,9 @@ define([
 
     // Tailer
     require([
-      './reveal.js/lib/js/head.min.js',
+      // no longer current
+      // https://github.com/hakimel/reveal.js/commit/29b0e86089eb3ec0d4bb5811c9b723dfcf36703c
+      // './reveal.js/lib/js/head.min.js',
       './reveal.js/js/reveal.js'
     ].map(require.toUrl),
             function(){

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -603,8 +603,8 @@ define([
                 //console.log("Reveal is already initialized and is being configured");
               } else {
                 Reveal.initialize(options);
-                Reveal["initialized"] = true;
                 //console.log("Reveal initialized");
+                Reveal.initialized = true;
               }
 
               Reveal.addEventListener('ready', function(event) {

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -280,3 +280,8 @@
 #chalkboard {
   display: none;
 }
+
+/* fix for issue #425 */
+.rise-enabled .rendered_html table {
+  font-size: 75%;
+}

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -55,7 +55,9 @@
       .transition-all;
       right: 3.3em;
       bottom: 3.9em;
+    /* more harmful than helpful with reveal 3.8.0
       font-size: 100%;
+    */
       color: @some-grey;
       background-color: transparent;
     }


### PR DESCRIPTION
this is WIP and not working; most obvious broken feature at this point is themes, and more specifically theme backgrounds, that do not render as expected

I'm exposing this so that others can experiment with and feedback about an angle that I think may be worth fiddling with

in a nutshell: as mentioned a few times in some other issues like #435 and #438, when running a RISE slideshow we primarily enable 3 source of css styling: jupyter, RISE and reveal

the way reveal themes are implemented for example sets attributes on `body` which tends to potentially have rather devastating effects

the angle I have taken in this one-line approach is to monkey-patch the official reveal themes (as downloaded after `npm install`) so as to make their `body` css rule more specific, and to give them a chance to override stuff - for example to override settings made in `notebook.less` on the `body` tag too.

---
this at this point is not working; it does improve the situation a bit, in that when inspecting the <body> tag through web devel tools, the theme settings do show up as applying, but for some yet-to-be-figured reasons the background still gets rendered blank..

Any hint would be btw much appreciated about that matter, it currently beats me why background themes don't get rendered.