### PR TITLE
Use data-base-url to determine the Jupyter server root

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -490,7 +490,10 @@ define([
       // asscosiated css
       let name_css = name.replace(".ipynb", ".css");
       // typically /files/examples/
-      let prefix = `/files/${path.replace(name, '')}`;
+      if (typeof($('body').attr("data-base-url")) == 'undefined') {
+          $('body').attr("data-base-url", '/')
+      }
+      let prefix = $('body').attr("data-base-url") + `files/${path.replace(name, '')}`;
       // Attempt to load rise.css
       $('head').append(
           `<link rel="stylesheet" href="${prefix}rise.css" id="rise-custom-css" />`);


### PR DESCRIPTION
Currently, RISE looks for the CSS stylesheets with a path derived from the relative path to the notebook. This works fine when running Jupyter locally - however, problems arise when Jupyter is not running on the server root (say, when running on Binder). This patch obtains the appropriate path from the `data-base-url` attribute of `<body>`, allowing CSS stylesheets to work on Binder as well.