### PR TITLE
Pass chalkboard options to reveal.

### DIFF
--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -574,6 +574,9 @@ define([
               ////////// set up chalkboard if configured
               let enable_chalkboard = complete_config.enable_chalkboard;
               if (enable_chalkboard) {
+				if ("chalkboard" in complete_config) {
+					options["chalkboard"] = complete_config["chalkboard"];
+				}
                 options.dependencies.push({ src: require.toUrl('./reveal.js-chalkboard/chalkboard.js'), async: true });
                 // xxx need to explore the option of registering jupyter actions
                 // and have jupyter handle the keyboard entirely instead of this approach


### PR DESCRIPTION
This resolves #505 by passing chalkboard settings to reveal if the chalkboard is enabled and the settings are present in `rise.json`. 