### PR TITLE
custom chalkboard key config added (main.js + rise.yaml)

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -499,3 +499,57 @@ Note that with this approach, you will end up with the
 The actions exposed to Jupyter are also present in Jupyter's
 mainstream keyboard shortcuts editor, that you can use to (un)define
 your custom shortcuts.
+
+### Native keyboard shortcuts for reveal.js and reveal.js plug-ins 
+
+Some custom keyboard shortcuts may be defined in RISE to override the default 
+keyboard shortcuts of `reveal.js` and/or its plug-ins.
+
+The key bindings can be defined via the `nbextensions_configurator` or directly 
+in JSON.
+
+The table below shows the avaialble key bindings:
+
+	module      action               default key  behaviour
+    ---------------------------------------------------------
+    main        firstSlide           home         jump to first slide
+    main        lastSlide            end          jump to last slide
+    main        toggleOverview       w            toggles slide overview
+    main        toggleAllRiseButtons ,            show/hide buttons
+    main        fullscreenHelp       f            show fullscreen help
+    main        riseHelp             ?            show the RISE help
+    chalkboard  clear                -            clear full size chalkboard
+    chalkboard  reset                =            reset chalkboard data on current slide
+    chalkboard  toggleChalkboard     [            toggle full size chalkboard
+    chalkboard  toggleNotesCanvas    ]            toggle notes (slide-local)
+    chalkboard  download             \            download recorded chalkboard drawing
+
+In JSON the native reveal.js keyboard shortcuts can be defined as shown in the 
+example below:
+
+    {
+     ...
+     "rise": {
+         "reveal_shortcuts": {
+             "main": {
+                "toggleOverview": "tab"
+             },
+             "chalkboard": {
+                "clear": "delete,c"
+             }
+         }
+    }
+
+Note, that it is not possible to define key combinations (e.g. `Alt-C`) for 
+the native reveal.js short cuts.
+
+Also note, that some key bindings may not be supported depending on your OS, 
+browser and/or keyboard layout.
+
+Unlike in the typical jupyter notebook logic - multiple keys seperated by a 
+comma (e.g. `"delete,c"`) do not represent a succession of keys, that needs to 
+be pressed.
+Instead they define alternative key bindings for the same action - e.g. in the 
+example above the action to clear the chalkboard would be bound to both 
+the `delete`- as well as the `c`-key. 
+

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -496,7 +496,7 @@ define([
 	}
 	return keycodes;
   }
-
+  
   function Revealer(selected_slide) {
     $('body').addClass("rise-enabled");
     // Prepare the DOM to start the slideshow
@@ -539,7 +539,66 @@ define([
         $('#help_b,#exit_b,#toggle-chalkboard,#toggle-notes').fadeToggle()
     }
     
-    
+    /*
+     * Creates a dictionary with keyboard bindings (keycode: Action) for 
+     * reveal.js and its plug-ins (e.g. RevealChalkboard).
+     */
+    function createKeyBindingsDict(default_bindings, custom_shortcuts){
+    	
+        var custom_shortcuts_keys;
+        
+        if (typeof custom_shortcuts === 'undefined'){
+        	custom_shortcuts_keys = [];
+        }
+        else{
+        	custom_shortcuts_keys = Object.keys(custom_shortcuts);
+        }
+        //console.log("Chalkboard keys:", cb_shortcuts_keys);
+        
+        var key;
+        var keycode;
+        var keycodes;
+        var shortcut_keys;
+        var nbconf_name;
+        var reveal_bindings = {};
+        var keys_dict;
+        
+        // check if custom binding are defined and in case overwrite default
+        for (const key_binding of custom_shortcuts_keys){
+        	if (Object.keys(default_bindings).includes(key_binding)){
+        		shortcut_keys = custom_shortcuts[key_binding];
+        		//console.log("Found action", key_binding, "bound to key", shortcut_keys);
+        		keys_dict = getKeyCodes(shortcut_keys);
+        		//console.log(`keys_dict: ${JSON.stringify(keys_dict)}`);
+        		keycodes = [];
+        		for (const key_dict of keys_dict){
+        			keycodes.push(key_dict['code']);
+        		}
+        		// only update the default dict, if valid key codes were found
+        		if (keycodes.length >= 0){
+        			default_bindings[key_binding]['keycodes'] = keycodes;
+        		}
+        	}
+        	else{	// if the key binding is not defined in the default bindings ignore it
+        		console.log(`Unkown key binding \"${key_binding}\" found. Will be ignored!`);
+        		// if we would add the API actions in nbconfig, we could provide access
+        		// to the complete API of reveal.js and its plug-ins. This would 
+        		// however be a bit of a challenge to manage with nbextensions_configurator
+        	}
+        }
+        
+        // iterate through (update default_bindings) and export to keyboard binding dict for reveal.js
+        for (const key_binding of Object.keys(default_bindings)){ 
+        	// for each key code (if multiple keys assigned to same binding)
+			for (keycode of default_bindings[key_binding]['keycodes']) {
+	    		//keycode = nbconfig_keys[nbconf_name]['keycode']; 
+	    		//console.log(`nbconf_name: ${nbconf_name}, keycode: ${keycode}`);
+	    		reveal_bindings[keycode] = default_bindings[key_binding]['call'];
+	    	}
+        }
+        //console.log(`reveal_bindings: ${JSON.stringify(reveal_bindings)}`);
+		return reveal_bindings;
+    }
 
     // Tailer
     require([
@@ -568,13 +627,18 @@ define([
                 // turn off reveal native help
                 help: false,
 
+                // key bindings configurable by nbconfig  are defined below - 
+                // this shall only be used for hard wired bindings, which should 
+                // not be adjustable by user settings.
                 keyboard: {
                   13: null, // Enter disabled
                   27: null, // ESC disabled
+                  35: null, // End - last slide disabled (will be set in custom keys)
+                  36: null, // Home - first slide disabled (will be set in custom keys)
                   38: null, // up arrow disabled
                   40: null, // down arrow disabled
                   66: null, // b, black pause disabled, use period or forward slash
-                  70: fullscreenHelp, // disable fullscreen inside the slideshow, makes codemirror unreliable
+                  // 70: fullscreenHelp, // disable fullscreen inside the slideshow, makes codemirror unreliable
                   72: null, // h, left disabled
                   74: null, // j, down disabled
                   75: null, // k, up disabled
@@ -583,8 +647,8 @@ define([
                   79: null, // o disabled
                   80: null, // p, up disabled
                   // 84: RevealNotes.open, // t, modified in the custom notes plugin.
-                  87: Reveal.toggleOverview, // w, toggle overview
-                  188: toggleAllRiseButtons, // comma
+                  // 87: Reveal.toggleOverview, // w, toggle overview
+                  // 188: toggleAllRiseButtons, // comma
                 },
 
                 dependencies: [
@@ -612,7 +676,47 @@ define([
                 options.dependencies.push({ src: require.toUrl('./reveal.js/plugin/leap/leap.js'), async: true });
                 options.leap = enable_leap_motion;
               }
-
+              
+              ////////// extend reveal.js with custom key bindings to reveal.js and RISE API
+              var default_reveal_bindings = 
+              {
+            	'firstSlide': {	// jump to first slide
+	      		    'keycodes': [36],	// defaults to home key
+	    			'call': () => Reveal.slide(0)
+	    		},
+	    		'lastSlide': {	// jump to last slide
+	    			'keycodes': [35],	// defaults to end key
+	    			'call': () => Reveal.slide( Number.MAX_VALUE )
+	    		},
+	    		'toggleOverview': {	// toggle overview
+	    			'keycodes': [87],	// defaults to w
+	    			'call': () => Reveal.toggleOverview()
+	    		},
+	    		'toggleAllRiseButtons': {	// show/hide buttons
+	    			'keycodes': [188],	// defaults to ,
+	    			'call': toggleAllRiseButtons
+	    		},
+	    		'fullscreenHelp': {	// show fullscreen help
+	    			'keycodes': [70],	// defaults to f
+	    			'call': fullscreenHelp
+	    		},
+	    		'riseHelp': {	// '?' show our help
+        			'keycodes': [63],
+        			'call': riseHelp
+        		},
+	    	  }
+              // check if custom reveal shortcuts are defined at all
+              var custom_reveal_shortcuts;
+              if (typeof complete_config.reveal_shortcuts === 'undefined'){
+            	  custom_reveal_shortcuts = undefined;
+              }
+              else{
+            	  custom_reveal_shortcuts = complete_config.reveal_shortcuts.main;
+              }
+              var reveal_bindings = createKeyBindingsDict(default_reveal_bindings,
+            		  custom_reveal_shortcuts);
+              $.extend(options.keyboard, reveal_bindings);
+	    	  
               ////////// set up chalkboard if configured
               let enable_chalkboard = complete_config.enable_chalkboard;
               if (enable_chalkboard) {
@@ -625,12 +729,9 @@ define([
                 // alternative keys can now be defined in nbextension_configurator and
                 // are converted to keyevent code by the getKeyCodes function
                 
+                ///// add custom key bindings to RevealChalkboard API
                 // default chalkboard key codes as defined in nbextension_configurator (see rise.yaml)
-                var nbconfig_keys = {
-            		'riseHelp': {	// '?' show our help
-            			'keycodes': [63],
-            			'call': riseHelp
-            		},
+                var default_cb_bindings = {
             		'clear': {	// '-' clear full size chalkboard
             			'keycodes': [189],
                 		'call': () => RevealChalkboard.clear()
@@ -654,54 +755,18 @@ define([
                 };
                 
                 // add user defined keycodes, if defined via nbextensions_configurator
-                const cb_shortcuts = complete_config.cb_shortcuts;
-                var cb_shortcuts_keys;
-                if (typeof cb_shortcuts === 'undefined'){
-                	cb_shortcuts_keys = [];
+                // check if custom reveal shortcuts are defined at all
+                var custom_cb_shortcuts;
+                if (typeof complete_config.reveal_shortcuts === 'undefined'){
+              	  custom_cb_shortcuts = undefined;
                 }
                 else{
-                	cb_shortcuts_keys = Object.keys(cb_shortcuts);
+              	  custom_cb_shortcuts = complete_config.reveal_shortcuts.chalkboard;
                 }
-                //console.log("Chalkboard keys:", cb_shortcuts_keys);
-                
-                var key;
-                var keycode;
-                var keycodes;
-                var shortcut_keys;
-                var nbconf_name;
-                var cb_keycodes = {};
-                var keys_dict;
-
-                for (const nbconf_name of Object.keys(nbconfig_keys)){               	
-                	// if key code was redefined, it is in complete_config_keys
-                	// update nbconfig_keys in this case
-		        	if (cb_shortcuts_keys.includes(nbconf_name)){
-		        		shortcut_keys = cb_shortcuts[nbconf_name];
-		        		//console.log("Found action", nbconf_name, "bound to key", shortcut_keys);
-
-		        		
-		        		keys_dict = getKeyCodes(shortcut_keys);
-		        		//console.log(`keys_dict: ${JSON.stringify(keys_dict)}`);
-		        		keycodes = [];
-		        		for (const key_dict of keys_dict){
-		        			keycodes.push(key_dict['code']);
-		        		}
-		        		
-		        		// only update the keycodes,
-		        		if (keycodes.length >= 0){
-		        			nbconfig_keys[nbconf_name]['keycodes'] = keycodes;
-		        		}
-		            }
-		        	// assign keycodes to dictionary format for chalkboard key bindings
-		        	for (keycode of nbconfig_keys[nbconf_name]['keycodes']) {
-		        		//keycode = nbconfig_keys[nbconf_name]['keycode']; 
-		        		//console.log(`nbconf_name: ${nbconf_name}, keycode: ${keycode}`);
-		        		cb_keycodes[keycode] = nbconfig_keys[nbconf_name]['call'];
-		        	}
-                }
-                //console.log(`stats: ${JSON.stringify(cb_keycodes)}`);
-                $.extend(options.keyboard, cb_keycodes);
-               }
+                var cb_bindings = createKeyBindingsDict(default_cb_bindings,
+              		  custom_cb_shortcuts);
+                $.extend(options.keyboard, cb_bindings);
+              }
 
               if (Reveal.initialized) {
                 //delete options["dependencies"];
@@ -851,27 +916,61 @@ define([
 	return key_str;
   }
   
+  /*
+   * Creates a list item string for help dialog
+   * 
+   * Args:
+   * shortcut_str = string representation of keyboard shortcut(s)
+   * default_str = default (fall back) string for key
+   * help_str = help text to be shown for item
+   */
+  function createListItemStr(shortcut_str, default_str, help_str){
+	  var item_str;
+	  
+	  var item_key_str = createShortCutStr(shortcut_str, default_str);
+	  
+	  item_str = "<li>" + item_key_str + ": " + help_str + "</li>"
+	  
+	  return item_str
+  }
+   
   function riseHelp() {
-	var cb_keys = complete_config.cb_shortcuts;
-	if (typeof cb_keys === "undefined"){
-		cb_keys = {};
+	var reveal_keys;
+	var cb_keys;
+	
+	//check if custom key bindings for reveal & chalkboard are defined  
+	if (typeof complete_config.reveal_shortcuts !== 'undefined'){
+		if (typeof complete_config.reveal_shortcuts.main !== 'undefined'){
+			reveal_keys = complete_config.reveal_shortcuts.main;
+		}
+		else{
+			reveal_keys = {};
+		}
+		if (typeof complete_config.reveal_shortcuts.chalkboard !== 'undefined'){
+			cb_keys = complete_config.reveal_shortcuts.chalkboard;
+		}
+		else{
+			cb_keys = {};
+		}
 	}
 	else{
-		cb_keys = complete_config.cb_shortcuts;
+		reveal_keys = {};
+		cb_keys = {};
 	}
-	
+		
     let message = $('<div/>').append(
       $("<p/></p>").addClass('dialog').html(
         "<ul>" +
+          createListItemStr(reveal_keys.riseHelp, '?', 'Show this help dialog') +
           "<li><kbd>Alt</kbd>+<kbd>r</kbd>: enter/exit RISE</li>" +
           "<li><kbd>Space</kbd>: next</li>" +
           "<li><kbd>Shift</kbd>+<kbd>Space</kbd>: previous</li>" +
           "<li><kbd>Shift</kbd>+<kbd>Enter</kbd>: eval and select next cell if visible</li>" +
-          "<li><kbd>Home</kbd>: first slide</li>" +
-          "<li><kbd>End</kbd>: last slide</li>" +
-          "<li><kbd>w</kbd>: toggle overview mode</li>" +
+          createListItemStr(reveal_keys.firstSlide, 'Home', 'first slide') +
+          createListItemStr(reveal_keys.lastSlide, 'End', 'last slide') +
+          createListItemStr(reveal_keys.toggleOverview, 'w', 'toggle overview mode') +
           "<li><kbd>t</kbd>: toggle notes</li>" +
-          "<li><kbd>,</kbd>: toggle help and exit buttons</li>" +
+          createListItemStr(reveal_keys.toggleAllRiseButtons, ',', 'show/hide help and exit buttons') +
           "<li><kbd>/</kbd>: black screen</li>" +
           "<li><strong>less useful:</strong>" +
             "<ul>" +
@@ -882,11 +981,11 @@ define([
             "</ul>" +
           "<li><strong>with chalkboard enabled:</strong>" +
             "<ul>" +
-            `<li>${createShortCutStr(cb_keys.toggleChalkboard, '[')} toggle fullscreen chalkboard</li>` +
-            `<li>${createShortCutStr(cb_keys.toggleNotesCanvas, ']')} toggle slide-local canvas</li>` +
-            `<li>${createShortCutStr(cb_keys.download, '\\')} download chalkboard drawing</li>` +
-            `<li>${createShortCutStr(cb_keys.reset, '=')} clear slide-local canvas</li>` +
-            `<li>${createShortCutStr(cb_keys.clear, '-')} delete fullscreen chalkboard</li>` +
+            createListItemStr(cb_keys.toggleChalkboard, '[', 'toggle fullscreen chalkboard') +
+            createListItemStr(cb_keys.toggleNotesCanvas, ']', 'toggle slide-local canvas') +
+            createListItemStr(cb_keys.download, '\\', 'download chalkboard drawing') +
+            createListItemStr(cb_keys.reset, '=', 'clear slide-local canvas') +
+            createListItemStr(cb_keys.clear, '-', 'delete fullscreen chalkboard') +
             "</ul>" +
           "</ul>" +
           "<b>NOTE</b>: of course you have to use these shortcuts <b>in command mode.</b>"

--- a/rise/static/main.js
+++ b/rise/static/main.js
@@ -628,8 +628,7 @@ define([
                 help: false,
 
                 // key bindings configurable by nbconfig  are defined below - 
-                // this shall only be used for hard wired bindings, which should 
-                // not be adjustable by user settings.
+                // this should only be used to unbind keys
                 keyboard: {
                   13: null, // Enter disabled
                   27: null, // ESC disabled
@@ -638,7 +637,7 @@ define([
                   38: null, // up arrow disabled
                   40: null, // down arrow disabled
                   66: null, // b, black pause disabled, use period or forward slash
-                  // 70: fullscreenHelp, // disable fullscreen inside the slideshow, makes codemirror unreliable
+                  70: null, // disable fullscreen inside the slideshow, makes codemirror unreliable
                   72: null, // h, left disabled
                   74: null, // j, down disabled
                   75: null, // k, up disabled
@@ -646,9 +645,9 @@ define([
                   78: null, // n, down disabled
                   79: null, // o disabled
                   80: null, // p, up disabled
-                  // 84: RevealNotes.open, // t, modified in the custom notes plugin.
-                  // 87: Reveal.toggleOverview, // w, toggle overview
-                  // 188: toggleAllRiseButtons, // comma
+                  84: null, // t, modified in the custom notes plugin.
+                  87: null, // w, toggle overview
+                  188: null, // comma
                 },
 
                 dependencies: [

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -34,8 +34,58 @@ Parameters:
     <li><code>=</code>to reset chalkboard drawing on the current slide;</li>
     <li><code>-</code> to clear the chalkboard.</li>
     </ul>
+    You can define alternative short cuts using the 
+    <code>rise.cb_shortcuts.*</code> parameters below. Note, that some keys 
+    might not work in some browsers.
   input_type: checkbox
   default: false
+# using cb_shortcuts for the chalkboard short cuts instead of shortcuts to 
+# avoid treating these as normal jupyter shortcuts
+- name: rise.cb_shortcuts.riseHelp
+  description: >
+    <code>rise.cb_shortcuts.riseHelp</code>: shortcut for showing 
+    help (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.cb_shortcuts.reset
+  description: >
+    <code>rise.cb_shortcuts.reset</code>: shortcut (in chalkboard mode) for resetting 
+    chalkboard data on current slide (<strong>key combinations are not supported
+    </strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.cb_shortcuts.clear
+  description: >
+    <code>rise.cb_shortcuts.clear</code>: shortcut (in chalkboard mode) for clearing 
+    full size chalkboard (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.cb_shortcuts.toggleChalkboard
+  description: >
+    <code>rise.cb_shortcuts.toggleChalkboard</code>: shortcut (in chalkboard mode) for 
+    toggling full size chalkboard (<strong>key combinations are not supported
+    </strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.cb_shortcuts.toggleNotesCanvas
+  description: >
+    <code>rise.cb_shortcuts.toggleNotesCanvas</code>: shortcut (in chalkboard mode) 
+    for toggling notes (slide-local) (<strong>key combinations are not supported
+    </strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.cb_shortcuts.download
+  description: >
+    <code>rise.cb_shortcuts.download</code>: shortcut (in chalkboard mode) for 
+    downloading recorded chalkboard drawing (<strong>key combinations are not 
+    supported</strong>)
+  input_type: hotkey
+  default: none
 #
 - name: rise.enable_leap_motion
   description: >

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -35,55 +35,83 @@ Parameters:
     <li><code>-</code> to clear the chalkboard.</li>
     </ul>
     You can define alternative short cuts using the 
-    <code>rise.cb_shortcuts.*</code> parameters below. Note, that some keys 
-    might not work in some browsers.
+    <code>rise.reveal_shortcuts.chalkboard.*</code> parameters below. Note, that some 
+    keys might not work in some browsers.
   input_type: checkbox
   default: false
-# using cb_shortcuts for the chalkboard short cuts instead of shortcuts to 
-# avoid treating these as normal jupyter shortcuts
-- name: rise.cb_shortcuts.riseHelp
+# using reveal_shortcuts for the reveal.js and chalkboard short cuts instead of 
+# shortcuts to avoid treating these as normal jupyter shortcuts
+- name: rise.reveal_shortcuts.chalkboard.reset
   description: >
-    <code>rise.cb_shortcuts.riseHelp</code>: shortcut for showing 
-    help (<strong>key combinations are not supported</strong>)
-  input_type: hotkey
-  default: none
-#
-- name: rise.cb_shortcuts.reset
-  description: >
-    <code>rise.cb_shortcuts.reset</code>: shortcut (in chalkboard mode) for resetting 
+    <code>rise.reveal_shortcuts.chalkboard.reset</code>: shortcut (in chalkboard mode) for resetting 
     chalkboard data on current slide (<strong>key combinations are not supported
     </strong>)
   input_type: hotkey
   default: none
 #
-- name: rise.cb_shortcuts.clear
+- name: rise.reveal_shortcuts.chalkboard.clear
   description: >
-    <code>rise.cb_shortcuts.clear</code>: shortcut (in chalkboard mode) for clearing 
+    <code>rise.reveal_shortcuts.chalkboard.clear</code>: shortcut (in chalkboard mode) for clearing 
     full size chalkboard (<strong>key combinations are not supported</strong>)
   input_type: hotkey
   default: none
 #
-- name: rise.cb_shortcuts.toggleChalkboard
+- name: rise.reveal_shortcuts.chalkboard.toggleChalkboard
   description: >
-    <code>rise.cb_shortcuts.toggleChalkboard</code>: shortcut (in chalkboard mode) for 
+    <code>rise.reveal_shortcuts.chalkboard.toggleChalkboard</code>: shortcut (in chalkboard mode) for 
     toggling full size chalkboard (<strong>key combinations are not supported
     </strong>)
   input_type: hotkey
   default: none
 #
-- name: rise.cb_shortcuts.toggleNotesCanvas
+- name: rise.reveal_shortcuts.chalkboard.toggleNotesCanvas
   description: >
-    <code>rise.cb_shortcuts.toggleNotesCanvas</code>: shortcut (in chalkboard mode) 
+    <code>rise.reveal_shortcuts.chalkboard.toggleNotesCanvas</code>: shortcut (in chalkboard mode) 
     for toggling notes (slide-local) (<strong>key combinations are not supported
     </strong>)
   input_type: hotkey
   default: none
 #
-- name: rise.cb_shortcuts.download
+- name: rise.reveal_shortcuts.chalkboard.download
   description: >
-    <code>rise.cb_shortcuts.download</code>: shortcut (in chalkboard mode) for 
+    <code>rise.reveal_shortcuts.chalkboard.download</code>: shortcut (in chalkboard mode) for 
     downloading recorded chalkboard drawing (<strong>key combinations are not 
     supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.reveal_shortcuts.main.riseHelp
+  description: >
+    <code>rise.reveal_shortcuts.main.riseHelp</code>: shortcut for showing 
+    help (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.reveal_shortcuts.main.firstSlide
+  description: >
+    <code>rise.reveal_shortcuts.main.firstSlide</code>: shortcut for jump to first 
+    slide (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.reveal_shortcuts.main.lastSlide
+  description: >
+    <code>rise.reveal_shortcuts.main.lastSlide</code>: shortcut for jump to last 
+    slide (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.reveal_shortcuts.main.toggleOverview
+  description: >
+    <code>rise.reveal_shortcuts.main.toggleOverview</code>: shortcut for slides 
+    overview (<strong>key combinations are not supported</strong>)
+  input_type: hotkey
+  default: none
+#
+- name: rise.reveal_shortcuts.main.toggleAllRiseButtons
+  description: >
+    <code>rise.reveal_shortcuts.main.toggleAllRiseButtons</code>: shortcut 
+    show/hide RISE buttons (<strong>key combinations are not supported</strong>)
   input_type: hotkey
   default: none
 #


### PR DESCRIPTION
Hi,
I have added some code to customize the keyboard short cuts for the chalkboard (as most of the hard wired default keys are not available on my german keyboard).

I guess this is not the perfect solution (read the discussion in #442), but it allows using some custom hotkey fields in nbconfig and converts the key-strings into key codes, which are then passed to the RevealChalkboard setup (could be used for other reveal.js keys as well, I guess...).

Conversion is done by a pretty simple string concatenation of the nbconfig key-shortcut string(s) to KeyEvent's VirtualKeyboardConstants (DOM_VK_...) - falls back to the default key codes, if no match is found.
I also added some code for updating the Rise help accordingly - so the help menu should always show the user defined shortcuts (if they could be converted).

Seems to work well on my system - linux/firefox (although some DOM_VK_... constants are missing), but I am rather new to javascript, so any feedback is welcome.

regards,
Thies