### PR TITLE
reveal.js/chalkboard API calls registered directly to jupyter shortcuts

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -515,7 +515,6 @@ The table below shows the avaialble key bindings:
     main        firstSlide           home         jump to first slide
     main        lastSlide            end          jump to last slide
     main        toggleOverview       w            toggles slide overview
-    main        toggleAllRiseButtons ,            show/hide buttons
     main        fullscreenHelp       f            show fullscreen help
     main        riseHelp             ?            show the RISE help
     chalkboard  clear                -            clear full size chalkboard
@@ -535,21 +534,9 @@ example below:
                 "toggleOverview": "tab"
              },
              "chalkboard": {
-                "clear": "delete,c"
+                "clear": "ctrl-k"
              }
          }
     }
 
-Note, that it is not possible to define key combinations (e.g. `Alt-C`) for 
-the native reveal.js short cuts.
-
-Also note, that some key bindings may not be supported depending on your OS, 
-browser and/or keyboard layout.
-
-Unlike in the typical jupyter notebook logic - multiple keys seperated by a 
-comma (e.g. `"delete,c"`) do not represent a succession of keys, that needs to 
-be pressed.
-Instead they define alternative key bindings for the same action - e.g. in the 
-example above the action to clear the chalkboard would be bound to both 
-the `delete`- as well as the `c`-key. 
 

--- a/rise/static/rise.yaml
+++ b/rise/static/rise.yaml
@@ -135,7 +135,7 @@ Parameters:
 - name: rise.shortcuts.toggle-notes
   description: <code>rise.shortcuts.toggle-notes</code> shortcut to toggle the 'notes' tag on current cell
   input_type: hotkey
-  default: none
+  default: t
 - name: rise.shortcuts.toggle-skip
   description: <code>rise.shortcuts.toggle-skip</code> shortcut to toggle the 'skip' tag on current cell
   input_type: hotkey
@@ -159,76 +159,74 @@ Parameters:
 - name: rise.reveal_shortcuts.main.riseHelp
   description: >
     <code>rise.reveal_shortcuts.main.riseHelp</code>: shortcut for showing 
-    help (<strong>key combinations are not supported</strong>)
+    help
   input_type: hotkey
-  default: none
+  default: "?"
 #
 - name: rise.reveal_shortcuts.main.firstSlide
   description: >
     <code>rise.reveal_shortcuts.main.firstSlide</code>: shortcut for jump to first 
-    slide (<strong>key combinations are not supported</strong>)
+    slide
   input_type: hotkey
-  default: none
+  default: home
 #
 - name: rise.reveal_shortcuts.main.lastSlide
   description: >
     <code>rise.reveal_shortcuts.main.lastSlide</code>: shortcut for jump to last 
-    slide (<strong>key combinations are not supported</strong>)
+    slide
   input_type: hotkey
-  default: none
+  default: end
 #
 - name: rise.reveal_shortcuts.main.toggleOverview
   description: >
     <code>rise.reveal_shortcuts.main.toggleOverview</code>: shortcut for slides 
-    overview (<strong>key combinations are not supported</strong>)
+    overview
   input_type: hotkey
-  default: none
-#
-- name: rise.reveal_shortcuts.main.toggleAllRiseButtons
-  description: >
-    <code>rise.reveal_shortcuts.main.toggleAllRiseButtons</code>: shortcut 
-    show/hide RISE buttons (<strong>key combinations are not supported</strong>)
-  input_type: hotkey
-  default: none
+  default: w
+# unfortunately jupyter does not allow to assign any keybinding to "," (comma)
+# and the function is not as easily accessable as the other functions
+# so "," is currently the only hard-wired keybind to reveal.js
+# - name: rise.reveal_shortcuts.main.toggleAllRiseButtons
+#   description: >
+#    <code>rise.reveal_shortcuts.main.toggleAllRiseButtons</code>: shortcut 
+#    show/hide RISE buttons
+#  input_type: hotkey
+#  default: m
 #
 - name: rise.reveal_shortcuts.chalkboard.reset
   description: >
     <code>rise.reveal_shortcuts.chalkboard.reset</code>: shortcut (in chalkboard mode) for resetting 
-    chalkboard data on current slide (<strong>key combinations are not supported
-    </strong>)
+    chalkboard data on current slide
   input_type: hotkey
-  default: none
+  default: minus
 #
 - name: rise.reveal_shortcuts.chalkboard.clear
   description: >
     <code>rise.reveal_shortcuts.chalkboard.clear</code>: shortcut (in chalkboard mode) for clearing 
-    full size chalkboard (<strong>key combinations are not supported</strong>)
+    full size chalkboard
   input_type: hotkey
-  default: none
+  default: "="
 #
 - name: rise.reveal_shortcuts.chalkboard.toggleChalkboard
   description: >
     <code>rise.reveal_shortcuts.chalkboard.toggleChalkboard</code>: shortcut (in chalkboard mode) for 
-    toggling full size chalkboard (<strong>key combinations are not supported
-    </strong>)
+    toggling full size chalkboard
   input_type: hotkey
-  default: none
+  default: "["
 #
 - name: rise.reveal_shortcuts.chalkboard.toggleNotesCanvas
   description: >
     <code>rise.reveal_shortcuts.chalkboard.toggleNotesCanvas</code>: shortcut (in chalkboard mode) 
-    for toggling notes (slide-local) (<strong>key combinations are not supported
-    </strong>)
+    for toggling notes (slide-local)
   input_type: hotkey
-  default: none
+  default: "]"
 #
 - name: rise.reveal_shortcuts.chalkboard.download
   description: >
     <code>rise.reveal_shortcuts.chalkboard.download</code>: shortcut (in chalkboard mode) for 
-    downloading recorded chalkboard drawing (<strong>key combinations are not 
-    supported</strong>)
+    downloading recorded chalkboard drawing
   input_type: hotkey
-  default: none
+  default: \
 
 #
 # passed to reveal as-is


### PR DESCRIPTION
After struggling to get all the special characters working with the DOM virtual keyboard constants approach for the custom keys (as I used for PR #525 ) and then having to realize that this isn't supported in google-chrome at all - I finally had a look at registering the key bindings directly in jupyter and it was actually pretty easy.

So here is a new PR based on having all the stuff set up in jupyter directly, which makes the whole thing much more robust and intuitive I would say. It also solves certain issues of the previous approach - like key combinations can now be used and you should be able to use every key in RISE you can type into the nbextension_configurator.

I had to add one hard-wired shortcut though. Jupyter does not allow to bind anything to "," (comma). And because the API call to the function behind this key (toggleAllRiseButtons) is also not as easily accessible as the rest, I made this one hard-wired again. I think it is okay in this case, because the key cannot be configured in jupyter and hence there will be no interference.

I also experienced some strange behavior, trying to set custom keys in nbextension_configurator. I can modify one short-cut, but the second, third,.. shortcut I try to change actually modifies the first one again and the one actually selected. I guess this not a RISE issue, but something in nbextension_configurator. I will have a closer look on it and eventually raise an issue on that topic.