### PR TITLE
Adding color support to chalkboard

### DIFF
--- a/classic/rise/static/main.js
+++ b/classic/rise/static/main.js
@@ -728,7 +728,10 @@ define([
         'colorNext': () => RevealChalkboard.colorNext(), // next color
         'colorPrev': () => RevealChalkboard.colorPrev(), // previous color
         'download': () => RevealChalkboard.download()  //  download recorded chalkboard drawing
-      }
+      },
+      'notes': { // API calls for RevealNotes plug-in
+          'openNotes' : () => RevealNotes.open(), // open speaker notes window
+      },
   }
   
   let reveal_helpstr = {
@@ -748,7 +751,10 @@ define([
         'colorNext': 'cycle to next pen color',
         'colorPrev': 'cycle to previous pen color',
         'download': 'download recorded chalkboard drawing'
-      }
+      },
+      'notes': { // API calls for RevealNotes plug-in
+          'openNotes' : 'open speaker notes windows'
+      },
   }
   
   // need to check, if we can fetch the default bindings from rise.yaml (nbconfig)
@@ -769,7 +775,10 @@ define([
         'colorPrev': 'q',               // keycode 81
         'colorNext': 's',               // kecode 83
         'download': '\\'                // keycode 220
-      }
+      },
+      'notes': { // API calls for RevealNotes plug-in
+          'openNotes' : 't'             // keycode 84
+      },
   }
   
   // update reveal bindings with custom key codes
@@ -874,6 +883,7 @@ define([
     let jupyter_keys;
     let reveal_keys;
     let cb_keys;
+    let no_keys;
     
     //check if custom bindings for registered jupyter calls are defined
     if (typeof complete_config.shortcuts !== 'undefined'){
@@ -889,8 +899,10 @@ define([
     
     reveal_keys = updated_keybindings['main'];
     cb_keys = updated_keybindings['chalkboard'];
+    no_keys = updated_keybindings['notes'];
     let reveal_help = reveal_helpstr['main'];
     let cb_help = reveal_helpstr['chalkboard'];
+    let no_help= reveal_helpstr['notes'];
     
     let message = $('<div/>').append(
       $("<p/></p>").addClass('dialog').html(
@@ -903,7 +915,7 @@ define([
           helpListItem(reveal_keys.firstSlide, reveal_help.firstSlide) +
           helpListItem(reveal_keys.lastSlide, reveal_help.lastSlide) +
           helpListItem(reveal_keys.toggleOverview, reveal_help.toggleOverview) +
-          helpListItem('t', 'toggle notes') +
+          helpListItem(no_keys.openNotes, no_help.openNotes) +
           `<li><kbd>,</kbd>: ${reveal_help.toggleAllRiseButtons}</li>` +
           "<li><kbd>/</kbd>: black screen</li>" +
           "<li><strong>less useful:</strong>" +
@@ -917,6 +929,8 @@ define([
           "<ul>" +
           helpListItem(cb_keys.toggleChalkboard, cb_help.toggleChalkboard) +
           helpListItem(cb_keys.toggleNotesCanvas, cb_help.toggleNotesCanvaas) +
+          helpListItem(cb_keys.colorNext, cb_help.colorNext) +
+          helpListItem(cb_keys.colorPrev, cb_help.colorPrev) +
           helpListItem(cb_keys.download, cb_help.download) +
           helpListItem(cb_keys.reset, cb_help.reset) +
           helpListItem(cb_keys.clear, cb_help.clear) +

--- a/classic/rise/static/main.js
+++ b/classic/rise/static/main.js
@@ -753,7 +753,7 @@ define([
         'download': 'download recorded chalkboard drawing'
       },
       'notes': { // API calls for RevealNotes plug-in
-          'openNotes' : 'open speaker notes windows'
+          'openNotes' : 'open speaker notes window'
       },
   }
   

--- a/classic/rise/static/main.js
+++ b/classic/rise/static/main.js
@@ -725,6 +725,8 @@ define([
         'reset': () => RevealChalkboard.reset(), // reset chalkboard data on current slide
         'toggleChalkboard': () => RevealChalkboard.toggleChalkboard(),  // toggle full size chalkboard
         'toggleNotesCanvas': () => RevealChalkboard.toggleNotesCanvas(), // toggle notes (slide-local)
+        'colorNext': () => RevealChalkboard.colorNext(), // next color
+        'colorPrev': () => RevealChalkboard.colorPrev(), // previous color
         'download': () => RevealChalkboard.download()  //  download recorded chalkboard drawing
       }
   }
@@ -743,6 +745,8 @@ define([
         'reset': 'reset chalkboard data on current slide',
         'toggleChalkboard': 'toggle full size chalkboard',
         'toggleNotesCanvas': 'toggle notes (slide-local)',
+        'colorNext': 'cycle to next pen color',
+        'colorPrev': 'cycle to previous pen color',
         'download': 'download recorded chalkboard drawing'
       }
   }
@@ -762,6 +766,8 @@ define([
         'reset': '=',                   // keycode 187 (and 61 on firefox)
         'toggleChalkboard': '[',        // keycode 219
         'toggleNotesCanvas': ']',       // keycode 221
+        'colorPrev': 'q',               // keycode 81
+        'colorNext': 's',               // kecode 83
         'download': '\\'                // keycode 220
       }
   }

--- a/rise-reveal/package.json
+++ b/rise-reveal/package.json
@@ -33,16 +33,17 @@
   ],
   "scripts": {
     "build": "for target in copy patch; do npm run $target; done",
-    "copy": "mkdir -p export; for dep in reveal.js reveal.js-chalkboard; do cp -r ./node_modules/$dep/ ./export/$dep/; done",
-    "patch": "for target in patch-reveal-css patch-notes patch-themes ; do npm run $target; done",
+    "copy": "mkdir -p export; for dep in reveal.js; do cp -r ./node_modules/$dep/ ./export/$dep/; done; cp -r ./node_modules/reveal.js-plugins/chalkboard ./export/reveal.js-chalkboard/",
+    "patch": "for target in patch-reveal-css patch-notes patch-themes patch-chalkboard ; do npm run $target; done",
     "patch-reveal-css": "sed -i.upstream '11 s_^_/*_' export/reveal.js/css/reveal.css",
     "patch-notes": "bash patch-notes-plugin.sh",
     "patch-themes": "bash patch-reveal-themes.sh",
+    "patch-chalkboard": "bash patch-chalkboard.sh",
     "clean": "rm -rf node_modules export"
   },
   "dependencies": {
-    "reveal.js": "~3.8.0",
-    "reveal.js-chalkboard": "~1.0.0"
+    "reveal.js": "~3.9.0",
+    "reveal.js-plugins": "rajgoel/reveal.js-plugins#3.9.0"
   },
   "version": "380.0.2"
 }

--- a/rise-reveal/package.json
+++ b/rise-reveal/package.json
@@ -28,12 +28,12 @@
     "url": "https://github.com/damianavila/RISE/issues"
   },
   "files": [
-      "export/reveal.js",
-      "export/reveal.js-chalkboard"
+    "export/reveal.js",
+    "export/reveal.js-chalkboard"
   ],
   "scripts": {
     "build": "for target in copy patch; do npm run $target; done",
-    "copy": "mkdir -p export; for dep in reveal.js; do cp -r ./node_modules/$dep/ ./export/$dep/; done; cp -r ./node_modules/reveal.js-plugins/chalkboard ./export/reveal.js-chalkboard/",
+    "copy": "mkdir -p export; cp -r ./node_modules/reveal.js/ ./export/reveal.js/; cp -r ./node_modules/reveal.js-plugins/chalkboard ./export/reveal.js-chalkboard/",
     "patch": "for target in patch-reveal-css patch-notes patch-themes patch-chalkboard ; do npm run $target; done",
     "patch-reveal-css": "sed -i.upstream '11 s_^_/*_' export/reveal.js/css/reveal.css",
     "patch-notes": "bash patch-notes-plugin.sh",
@@ -42,8 +42,8 @@
     "clean": "rm -rf node_modules export"
   },
   "dependencies": {
-    "reveal.js": "~3.9.0",
+    "reveal.js": "~3.9.2",
     "reveal.js-plugins": "rajgoel/reveal.js-plugins#3.9.0"
   },
-  "version": "380.0.2"
+  "version": "390.0.1"
 }

--- a/rise-reveal/patch-chalkboard.sh
+++ b/rise-reveal/patch-chalkboard.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+patch export/reveal.js-chalkboard/chalkboard.js <<EOF
+--- chalkboard.js.orig	2020-10-24 15:02:34.000000000 +0200
++++ chalkboard.js	2020-10-24 15:02:41.000000000 +0200
+@@ -152,7 +152,7 @@
+ 		button.style.top = toggleChalkboardButton.top ||  "auto";
+ 		button.style.right = toggleChalkboardButton.right ||  "auto";
+ 
+-		button.innerHTML = '<a href="#" onclick="RevealChalkboard.toggleChalkboard(); return false;"><i class="fa fa-pen-square"></i></a>'
++		button.innerHTML = '<a href="#" onclick="RevealChalkboard.toggleChalkboard(); return false;"><i class="fa fa-pencil-square"></i></a>'
+ 		document.querySelector(".reveal").appendChild( button );
+ 	}
+ 	if ( toggleNotesButton ) {
+@@ -169,7 +169,7 @@
+ 		button.style.top = toggleNotesButton.top ||  "auto";
+ 		button.style.right = toggleNotesButton.right ||  "auto";
+ 
+-		button.innerHTML = '<a href="#" onclick="RevealChalkboard.toggleNotesCanvas(); return false;"><i class="fa fa-pen"></i></a>'
++		button.innerHTML = '<a href="#" onclick="RevealChalkboard.toggleNotesCanvas(); return false;"><i class="fa fa-pencil"></i></a>'
+ 		document.querySelector(".reveal").appendChild( button );
+ 	}
+ //alert("Buttons");
+@@ -259,10 +259,11 @@
+ ** Storage
+ ******************************************************************/
+ 
+-	var storage = [
+-		{ width: Reveal.getConfig().width, height: Reveal.getConfig().height, data: []},
+-		{ width: Reveal.getConfig().width, height: Reveal.getConfig().height, data: []}
+-	];
++        var storage = [
++                        { width: drawingCanvas[0].width - 2 * drawingCanvas[0].xOffset, height: drawingCanvas[0].height - 2 * drawingCanvas[0].yOffset, data: []},
++                        { width: drawingCanvas[1].width, height: drawingCanvas[1].height, data: []}
++                ];
++
+ //console.log( JSON.stringify(storage));
+ 
+ 	var loaded = null;
+EOF


### PR DESCRIPTION
reveal.js-plugins added color support to chalkboard some time ago.

This PR moves reveal.js from 3.8.0 to 3.9.0 and imports chalkboard from the last stable v3 reveal-js.plugins
Two keys are binded to color cycling : I choose Q & S on my AZERTY keyboard but there are certainly better options.
