### PR TITLE
Update customize.md: typo `RISE/examples/header-footer.ipynb`` had extra `

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -169,8 +169,8 @@ is still responsible for cosmetic styling:
     }
 
 You can see some examples using these options at
-`RISE/examples/overlay.ipynb` and
-`RISE/examples/header-footer.ipynb``, or in binder respectively
+`RISE/examples/overlay.ipynb` and `RISE/examples/header-footer.ipynb`,
+or in binder respectively
 [![](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/damianavila/RISE/master?filepath=examples%2Foverlay.ipynb)
 [![](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/damianavila/RISE/master?filepath=examples%2Fheader-footer.ipynb)
 


### PR DESCRIPTION
Hello there,
Thanks again for this wonderful project, I just love it :clap:!
When browsing through [this page of the doc](https://rise.readthedocs.io/en/stable/usage.html#jupyterlab), I just saw a typo in Markdown markup:
![Capture d’écran_2021-02-16_06-04-58](https://user-images.githubusercontent.com/11994719/108020592-fb278b00-701c-11eb-913b-bc3a545c0a20.png)
This one-bit pull-request solves this typo.
Regards from France, -- @Naereen