### PR TITLE
DOC: Add link to improve theme discoverability.

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -31,6 +31,11 @@ general look and feel of the presentation) with:
      "rise": {"theme": "sky"}
     }
 
+For a listing of built-in themes to choose from, see the
+[reveal.js theme documentation][reveal_builtin_themes].
+
+[reveal_builtin_themes]: https://revealjs.com/themes/
+
 ### Choosing a transition
 
 The transition configuration defines what happens in between slides:


### PR DESCRIPTION
Thanks for this excellent project!

I'm in the process of starting a new presentation with RISE and was curious to experiment with the different built-in theme options. I looked around in the docs and didn't see any listing of the built-in themes, so I thought adding a link to the reveal.js theme page might be useful.

FWIW I ended up finding this info by `grep`ing for "sky" and finding `tests/themes/redo-all.sh`, which gave me an idea of what was supported (and what to search for to get more info).