### PR TITLE
Add center to documentation

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -255,7 +255,7 @@ category, RISE will pass through the following settings:
   for more details](https://github.com/hakimel/reveal.js#slide-number)
 
 * `center` to enable or disable vertical centering of slide contents
-* 
+
 * as well as `history`.
 
 ### Adding custom CSS

--- a/doc/customize.md
+++ b/doc/customize.md
@@ -254,6 +254,8 @@ category, RISE will pass through the following settings:
   numbers. Set to boolean `false` to turn off, [see `reveal.js`'s doc
   for more details](https://github.com/hakimel/reveal.js#slide-number)
 
+* `center` to enable or disable vertical centering of slide contents
+* 
 * as well as `history`.
 
 ### Adding custom CSS


### PR DESCRIPTION
RISE does actually support passing through "center" to reveal.js but the docs don't say it's one of the supported options. This PR adds it to the docs.