### PR TITLE
Fix sync_timeout parameter

### DIFF
--- a/classic/rise/static/rise.yaml
+++ b/classic/rise/static/rise.yaml
@@ -340,7 +340,7 @@ Parameters:
   input_type: number
   default: 500
 #
-- name: rise.aync_timeout
+- name: rise.sync_timeout
   description: >
     timeout in milliseconds before an extra call to Reveal.sync() is
     made to ensure proper display in some problematic conditions;


### PR DESCRIPTION
Currently the `sync_timeout` argument cannot be properly configured because it is mistakenly called `aync_timeout` in the config.