### PR TITLE
Relayout button

### DIFF
--- a/classic/rise/static/main.js
+++ b/classic/rise/static/main.js
@@ -82,7 +82,6 @@ define([
       shortcuts: {
         'slideshow' : 'alt-r',
         'relayout' : 'alt-q',
-        'relayout' : 'alt-q',
         'toggle-slide': 'shift-i',
         'toggle-subslide': 'shift-b',
         'toggle-fragment': 'shift-g',

--- a/classic/rise/static/main.js
+++ b/classic/rise/static/main.js
@@ -81,6 +81,8 @@ define([
       toolbar_icon: 'fa-bar-chart',
       shortcuts: {
         'slideshow' : 'alt-r',
+        'relayout' : 'alt-q',
+        'relayout' : 'alt-q',
         'toggle-slide': 'shift-i',
         'toggle-subslide': 'shift-b',
         'toggle-fragment': 'shift-g',
@@ -1238,6 +1240,14 @@ define([
       {help   : 'output RISE configuration in console, for debugging mostly',
        handler: showConfig},
       "rise-dump-config", "RISE");
+
+    actions.register({
+        help: 'force Reveal.JS to re-evaluate the layout',
+        handler: () => {
+          //Reveal.sync()
+          Reveal.layout()
+        }
+    }, "relayout", "RISE");
 
     let reveal_bindings = updateRevealBindings(reveal_default_bindings);
     // register all reveal.js actions for keyboard bindings

--- a/classic/rise/static/rise.yaml
+++ b/classic/rise/static/rise.yaml
@@ -161,6 +161,10 @@ Parameters:
     pane for the RISE extension in a new tab (or window, depending on your browser config).
   input_type: hotkey
   default: shift-c
+- name: rise.shortcuts.relayout
+  description: <code>rise.shortcuts.relayout</code> shortcut to force Reveal.JS to re-evaluate the layout, which can help resolve layout issues, for example if a slide has resized and isn't correctly located in the center of the slice.
+  input_type: hotkey
+  default: alt-q
 # using reveal_shortcuts for the reveal.js and chalkboard short cuts instead of 
 # shortcuts to avoid treating these as normal jupyter shortcuts
 - name: rise.reveal_shortcuts.main.riseHelp


### PR DESCRIPTION
This is a user friendly workaround to #625 or any similar layout issues that may arise. This PR adds a shortcut (by default `alt-q`, which forces Reveal.JS to recalculate the layout.