### PR TITLE
Add a link to the jupyterlab extension in the docs

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -120,8 +120,9 @@ You should press the `t` key to open the speaker notes view.
 
 ### JupyterLab
 
-Please be aware that as of 5.3 RISE is unfortunately not yet
-compatible with JupyterLab and must be used with the classic notebook.
+RISE is currently being ported to a [JupyterLab extension](https://github.com/jupyterlab-contrib/rise).
 
-See <https://github.com/damianavila/RISE/issues/270> for the github
-issue on this topic.
+For a stable experience keep using RISE with classic notebooks.
+
+See <https://github.com/damianavila/RISE/pull/605> for the github
+discussion on this topic.


### PR DESCRIPTION
I had quite an adventure in the Issues/PR sections until I found the amazing port to a jupyter lab extension.

thank you for the amazing work and please excuse me if any of the wording isn't accurate.